### PR TITLE
Experimental!

### DIFF
--- a/libs/hbb_common/src/udp.rs
+++ b/libs/hbb_common/src/udp.rs
@@ -49,7 +49,7 @@ impl FramedSocket {
 
     #[allow(clippy::never_loop)]
     pub async fn new_reuse<T: std::net::ToSocketAddrs>(addr: T) -> ResultType<Self> {
-        for addr in addr.to_socket_addrs()?.filter(|x| x.is_ipv4()) {
+        for addr in addr.to_socket_addrs()? {
             let socket = new_socket(addr, true, 0)?.into_udp_socket();
             return Ok(Self::Direct(UdpFramed::new(
                 UdpSocket::from_std(socket)?,
@@ -63,7 +63,7 @@ impl FramedSocket {
         addr: T,
         buf_size: usize,
     ) -> ResultType<Self> {
-        for addr in addr.to_socket_addrs()?.filter(|x| x.is_ipv4()) {
+        for addr in addr.to_socket_addrs()? {
             return Ok(Self::Direct(UdpFramed::new(
                 UdpSocket::from_std(new_socket(addr, false, buf_size)?.into_udp_socket())?,
                 BytesCodec::new(),


### PR DESCRIPTION
Bringing IPV6 ipv6 support on hbbr and hbbs
Tested on OpenSUSE Linux with Kernel 5.3.18-150300.59.63-default
This modifications will not work on linux if kernel option net.ipv6.bindv6only is 0
to settin up sysctl net.ipv6.bindv6only=1