### PR TITLE
small util for key management

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -66,6 +66,7 @@ jobs:
           path: |
             target/${{ matrix.job.target }}/release/hbbr
             target/${{ matrix.job.target }}/release/hbbs
+            target/${{ matrix.job.target }}/release/rustdesk-utils
           if-no-files-found: error
 
   # github (draft) release with all binaries
@@ -102,7 +103,7 @@ jobs:
           path: i386
 
       - name: Rename files
-        run: for arch in amd64 arm64v8 armv7 i386 ; do for b in hbbr hbbs ; do mv -v ${arch}/${b} ${arch}/${b}-${arch} ; done ; done 
+        run: for arch in amd64 arm64v8 armv7 i386 ; do for b in hbbr hbbs rustdesk-utils ; do mv -v ${arch}/${b} ${arch}/${b}-${arch} ; done ; done 
 
       - name: Create Release
         uses: softprops/action-gh-release@v1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,10 @@ default-run = "hbbs"
 name = "hbbr"
 path = "src/hbbr.rs"
 
+[[bin]]
+name = "rustdesk-utils"
+path = "src/utils.rs"
+
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,7 +1,7 @@
 use sodiumoxide::crypto::sign;
-use std::str;
 use std::env;
 use std::process;
+use std::str;
 
 fn print_help() {
     println!("Usage:");
@@ -28,41 +28,41 @@ fn gen_keypair() {
 fn validate_keypair(pk: &str, sk: &str) {
     let sk1 = base64::decode(&sk);
     match sk1 {
-        Ok(_) => {},
+        Ok(_) => {}
         Err(_) => {
             println!("Invalid secret key");
             process::exit(0x0001);
-        },
+        }
     }
     let sk1 = sk1.unwrap();
 
     let secret_key = sign::SecretKey::from_slice(sk1.as_slice());
     match secret_key {
-        Some(_) => {},
+        Some(_) => {}
         None => {
             println!("Invalid Secret key");
             process::exit(0x0001);
-        },
+        }
     }
     let secret_key = secret_key.unwrap();
 
     let pk1 = base64::decode(&pk);
     match pk1 {
-        Ok(_) => {},
+        Ok(_) => {}
         Err(_) => {
             println!("Invalid public key");
             process::exit(0x0001);
-        },
+        }
     }
     let pk1 = pk1.unwrap();
 
     let public_key = sign::PublicKey::from_slice(pk1.as_slice());
     match public_key {
-        Some(_) => {},
+        Some(_) => {}
         None => {
             println!("Invalid Public key");
             process::exit(0x0001);
-        },
+        }
     }
     let public_key = public_key.unwrap();
 
@@ -70,11 +70,11 @@ fn validate_keypair(pk: &str, sk: &str) {
     let signed_data = sign::sign(random_data_to_test, &secret_key);
     let verified_data = sign::verify(&signed_data, &public_key);
     match verified_data {
-        Ok(_) => {},
+        Ok(_) => {}
         Err(_) => {
             println!("Key pair is INVALID");
             process::exit(0x0001);
-        },
+        }
     }
     let verified_data = verified_data.unwrap();
 
@@ -99,8 +99,8 @@ fn main() {
             if args.len() <= 3 {
                 error_then_help("You must supply both the public and the secret key");
             }
-            validate_keypair(args[2].as_str(),args[3].as_str());
-        },
-        _=>print_help(),
+            validate_keypair(args[2].as_str(), args[3].as_str());
+        }
+        _ => print_help(),
     }
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,0 +1,106 @@
+use sodiumoxide::crypto::sign;
+use std::str;
+use std::env;
+use std::process;
+
+fn print_help() {
+    println!("Usage:");
+    println!("  rustdesk-util [command]\n");
+    println!("Available Commands:");
+    println!("  genkeypair                                   Generate a new keypair");
+    println!("  validatekeypair [public key] [secret key]    Validate an existing keypair");
+    process::exit(0x0001);
+}
+
+fn error_then_help(msg: &str) {
+    println!("ERROR: {}\n", msg);
+    print_help();
+}
+
+fn gen_keypair() {
+    let (pk, sk) = sign::gen_keypair();
+    let public_key = base64::encode(pk);
+    let secret_key = base64::encode(sk);
+    println!("Public Key:  {public_key}");
+    println!("Secret Key:  {secret_key}");
+}
+
+fn validate_keypair(pk: &str, sk: &str) {
+    let sk1 = base64::decode(&sk);
+    match sk1 {
+        Ok(_) => {},
+        Err(_) => {
+            println!("Invalid secret key");
+            process::exit(0x0001);
+        },
+    }
+    let sk1 = sk1.unwrap();
+
+    let secret_key = sign::SecretKey::from_slice(sk1.as_slice());
+    match secret_key {
+        Some(_) => {},
+        None => {
+            println!("Invalid Secret key");
+            process::exit(0x0001);
+        },
+    }
+    let secret_key = secret_key.unwrap();
+
+    let pk1 = base64::decode(&pk);
+    match pk1 {
+        Ok(_) => {},
+        Err(_) => {
+            println!("Invalid public key");
+            process::exit(0x0001);
+        },
+    }
+    let pk1 = pk1.unwrap();
+
+    let public_key = sign::PublicKey::from_slice(pk1.as_slice());
+    match public_key {
+        Some(_) => {},
+        None => {
+            println!("Invalid Public key");
+            process::exit(0x0001);
+        },
+    }
+    let public_key = public_key.unwrap();
+
+    let random_data_to_test = b"This is meh.";
+    let signed_data = sign::sign(random_data_to_test, &secret_key);
+    let verified_data = sign::verify(&signed_data, &public_key);
+    match verified_data {
+        Ok(_) => {},
+        Err(_) => {
+            println!("Key pair is INVALID");
+            process::exit(0x0001);
+        },
+    }
+    let verified_data = verified_data.unwrap();
+
+    if random_data_to_test == &verified_data[..] {
+        println!("Key pair is VALID");
+    } else {
+        println!("Key pair is INVALID");
+        process::exit(0x0001);
+    }
+}
+
+fn main() {
+    let args: Vec<_> = env::args().collect();
+    if args.len() <= 1 {
+        print_help();
+    }
+
+    let command = args[1].to_lowercase();
+    match command.as_str() {
+        "genkeypair" => gen_keypair(),
+        "validatekeypair" => {
+            if args.len() <= 3 {
+                error_then_help("You must supply both the public and the secret key");
+            }
+            validate_keypair(args[2].as_str(),args[3].as_str());
+        },
+        _=>print_help(),
+    }
+}


### PR DESCRIPTION
With this util, we add a way to generate and verify a keypair. The keypair generation is useful for first installation, especially when https://github.com/rustdesk/rustdesk-server/pull/61 gets approved.

The command will be something like:

```bash
docker run --rm --entrypoint /usr/bin/rustdesk-utils rustdesk/rustdesk-server:latest genkeypair
```

The expected output is something like this:

```text
Public Key:  e61C1tOULMqVbAf0kTlUbyBFNZ1eObXIOQ1O0BSSB/o=
Secret Key:  ZuDfy4g9/HO1U6003hTQSaFQNBT7XPpz4B4F2TOw9Uh7rULW05QsypVsB/SROVRvIEU1nV45tcg5DU7QFJIH+g==
```

The other available command is `validatekeypair` which is used to check if the keypair is valid:

```bash
rustdesk-utils validatekeypair 'e61C1tOULMqVbAf0kTlUbyBFNZ1eObXIOQ1O0BSSB/o=' 'ZuDfy4g9/HO1U6003hTQSaFQNBT7XPpz4B4F2TOw9Uh7rULW05QsypVsB/SROVRvIEU1nV45tcg5DU7QFJIH+g=='
```

This will be used at the container startup to check keypair validity before program startup.

# NOTE

This is the first time i use rust. I really can use the help of a skilled developer to check on this work; that's why this is a draft.