### PR TITLE
Use same volumes for hbbs and hbbr

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ services:
     image: rustdesk/rustdesk-server:latest
     command: hbbs -r rustdesk.example.com:21117
     volumes:
-      - ./hbbs:/root
+      - ./data:/root
     networks:
       - rustdesk-net
     depends_on:
@@ -30,7 +30,7 @@ services:
     image: rustdesk/rustdesk-server:latest
     command: hbbr
     volumes:
-      - ./hbbr:/root
+      - ./data:/root
     networks:
       - rustdesk-net
     restart: unless-stopped


### PR DESCRIPTION
The services hbbs and hbbr must use the same volume. Otherwise, different keys are used when encryption is enabled.