### PR TITLE
fix github action on manual build

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -210,8 +210,10 @@ jobs:
           echo "MAJOR_TAG=$M" >> $GITHUB_ENV
 
       # manifest for :1.2.3 tag
+      #  this has to run only if invoked by a new tag
       - name: Create and push manifest (:ve.rs.ion)
         uses: Noelware/docker-manifest-action@master
+        if: github.event_name != 'workflow_dispatch'
         with:
           base-image: ${{ secrets.DOCKER_IMAGE }}:${{ env.GIT_TAG }}
           extra-images: ${{ secrets.DOCKER_IMAGE }}:${{ env.GIT_TAG }}-amd64,${{ secrets.DOCKER_IMAGE }}:${{ env.GIT_TAG }}-arm64v8,${{ secrets.DOCKER_IMAGE }}:${{ env.GIT_TAG }}-armv7,${{ secrets.DOCKER_IMAGE }}:${{ env.GIT_TAG }}-i386


### PR DESCRIPTION
when a manual build is triggered, the "version" is not 1.3.6 but the branch name (master, main, fix-docker-manifest, ...) so the github action tries to make a manifest 2 times with the same tag and this lead the action to fail.

this just skip one of the two manifest if the action is manually triggered.