### PR TITLE
keypair verification before container startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,8 @@ We use these environment variables:
 You can obviously keep the key pair in a docker volume, but the best practices tells you to not write the keys on the filesystem; so we provide a couple of options.
 
 On container startup, the presence of the keypair is checked (`/data/id_ed25519.pub` and `/data/id_ed25519`) and if one of these keys doesn't exist, it's recreated from ENV variables or docker secrets.
+Then the validity of the keypair is checked: if public and private keys doesn't match, the container will stop.
+If you provide no keys, `hbbs` will generate one for you, and it'll place it in the default location.
 
 #### Use ENV to store the key pair
 

--- a/docker/rootfs/etc/s6-overlay/s6-rc.d/key-secret/up.real
+++ b/docker/rootfs/etc/s6-overlay/s6-rc.d/key-secret/up.real
@@ -26,10 +26,33 @@ if [ ! -f /data/id_ed25519 ] && [ ! "$KEY_PRIV" = "" ] ; then
   echo "Private key created from ENV variable"
 fi
 
-# fix perms
-if [ -f /data/id_ed25519.pub ] ; then
-  chmod 600 /data/id_ed25519.pub 
+# check if both keys provided
+if [ -f /data/id_ed25519.pub ] && [ ! -f /data/id_ed25519 ] ; then
+  echo "Private key missing."
+  echo "You must provide BOTH the private and the public key."
+  /run/s6/basedir/bin/halt
+  exit 1
 fi
-if [ -f /data/id_ed25519 ] ; then
-  chmod 600 /data/id_ed25519
+
+if [ ! -f /data/id_ed25519.pub ] && [ -f /data/id_ed25519 ] ; then
+  echo "Public key missing."
+  echo "You must provide BOTH the private and the public key."
+  /run/s6/basedir/bin/halt
+  exit 1
 fi
+
+# here we have either no keys or both
+
+# if we have both keys, we fix permissions and ownership
+# and check for keypair validation
+if [ -f /data/id_ed25519.pub ] && [ -f /data/id_ed25519 ] ; then
+  chmod 0600 /data/id_ed25519.pub /data/id_ed25519
+  chown root:root /data/id_ed25519.pub /data/id_ed25519
+  /usr/bin/rustdesk-utils validatekeypair "$(cat /data/id_ed25519.pub)" "$(cat /data/id_ed25519)" || {
+    echo "Key pair not valid"
+    /run/s6/basedir/bin/halt
+    exit 1
+  }
+fi
+
+# if we have no keypair, hbbs will generate one


### PR DESCRIPTION
simple as that.

Either you start the container with a valid keypair or with no keypair (and it gets generated as usual)