### PR TITLE
debian support

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,5 +287,5 @@ These packages are meant for the following distributions:
 - Ubuntu 22.04 LTS
 - Ubuntu 20.04 LTS
 - Ubuntu 18.04 LTS
-
-Debian is currently not supported.
+- Debian 11 bullseye
+- Debian 10 buster

--- a/debian/rules
+++ b/debian/rules
@@ -1,3 +1,6 @@
 #!/usr/bin/make -f
 %:
 	dh $@
+
+override_dh_builddeb:
+	dh_builddeb -- -Zgzip


### PR DESCRIPTION
now deb packages are debian compatible.

tested with debian 11 (stable) and debian 10 (oldstable)

tested also with supported ubuntu (server)