### PR TITLE
rustdesk-server doctor

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,8 @@ http = "0.2"
 flexi_logger = { version = "0.22", features = ["async", "use_chrono_for_offset"] }
 ipnetwork = "0.20"
 local-ip-address = "0.4"
+dns-lookup = "1.0.8"
+ping = "0.4.0"
 
 [build-dependencies]
 hbb_common = { path = "libs/hbb_common" }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -132,13 +132,10 @@ fn doctor(server_address_unclean: &str) {
         let ips: Vec<std::net::IpAddr> = lookup_host(server_address).unwrap();
         println!("Found {} IP addresses: ", ips.iter().count());
 
-        for ip in ips.iter() {
-            println!(" - {}", ip);
-        }
+        ips.iter().for_each(|ip| println!(" - {ip}"));
 
-        for ip in ips.iter() {
-            doctor_ip(*ip, Some(server_address));
-        }
+        ips.iter().for_each(|ip| doctor_ip(*ip, Some(server_address)));
+
     } else {
         // user requested an ip address
         doctor_ip(server_ipaddr.unwrap(), None);


### PR DESCRIPTION
I added a small util to be run on a client machine to test for connectivity problems.

Example:

```bash
$ rustdesk-server doctor myrelay.rustdesk.com
Checking server:  myrelay.rustdesk.com

Found 1 IP addresses: 
 - 123.456.123.456

Checking IP address: 123.456.123.456
Is IPV4: true
Is IPV6: false
Reverse DNS lookup: 'vps444.provider.com' DOESN'T MATCH server address 'myrelay.rustdesk.com'
TCP Port 21114 (API): OK in 25 ms
TCP Port 21115 (hbbs extra port for nat test): OK in 21 ms
TCP Port 21116 (hbbs): OK in 21 ms
TCP Port 21117 (hbbr tcp): OK in 21 ms
TCP Port 21118 (hbbs websocket): OK in 24 ms
TCP Port 21119 (hbbr websocket): OK in 21 ms
```

I would like to add some more checks, like:

- ICMP ping (maybe not needed)
- key support (key required or not, check if a provided key is valid)
- client register test
- relay functionality test

As always, this is the first time I use rust, so I need vetting.

Please comment.