### PR TITLE
add '-k _' to hbbr if ENCRYPTED_ONLY is set

### DIFF
--- a/docker/rootfs/etc/s6-overlay/s6-rc.d/hbbr/run
+++ b/docker/rootfs/etc/s6-overlay/s6-rc.d/hbbr/run
@@ -1,3 +1,5 @@
 #!/command/with-contenv sh
 cd /data
-/usr/bin/hbbr
+PARAMS=
+[ "${ENCRYPTED_ONLY}" = "1" ] && PARAMS="-k _"
+/usr/bin/hbbr $PARAMS


### PR DESCRIPTION
The [documentation](https://rustdesk.com/docs/en/self-host/install/#key) suggests that `-k _` should be supplied to both `hbbs` and `hbbr` when only encrypted connections are permitted, but the [`rustdesk-server-s6`](https://hub.docker.com/r/rustdesk/rustdesk-server-s6) container doesn't appear to be doing this.

> If you want to prohibit users without the key from establishing non-encrypted connections, please add the -k _ parameter when running hbbs and hbbr, for example:
> `./hbbs -r <relay-server-ip[:port]> -k _`
> `./hbbr -k _`

Am I correct in understanding that anyone could currently be using the relay server (`hbbr`), even if `ENCRYPTED_ONLY=1`? ... and that the relay server will carry the majority of the bandwidth commitments, so it would be "_inviting_" to locate someone else's?

This patch resolves this situation by adding `-k _` to the `hbbr` service if `ENCRYPTED_ONLY=1`.