### PR TITLE
Update Cargo.toml for FreeBSD build

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ tower-http = { version = "0.3", features = ["fs", "trace", "cors"] }
 http = "0.2"
 flexi_logger = { version = "0.22", features = ["async", "use_chrono_for_offset"] }
 ipnetwork = "0.20"
-local-ip-address = "0.4"
+local-ip-address = "0.5.1"
 dns-lookup = "1.0.8"
 ping = "0.4.0"
 


### PR DESCRIPTION
Crate.io package local-ip-address from v0.5+ is Freebsd compatible, eg. it compiles and works. Simply changing the version to v0.5.1 in the Cargo.toml of rustdesk-server was possible to make a successful release build on FreeBSD 13 with prepackaged Rust 1.67.1. Working rc scripts available too.

Beyond the actual change, thinking about including FreeBSD release builds in the official releases.