### PR TITLE
FreeBSD rcd scripts for hbbs & hbbr

### DIFF
--- a/rcd/rustdesk-hbbr
+++ b/rcd/rustdesk-hbbr
@@ -1,0 +1,55 @@
+#!/bin/sh
+
+# PROVIDE: rustdesk_hbbr
+# REQUIRE: LOGIN
+# KEYWORD: shutdown
+#
+# Add the following lines to /etc/rc.conf.local or /etc/rc.conf
+# to enable this service:
+#
+# rustdesk_hbbr_enable (bool):            Set to NO by default.
+#               Set it to YES to enable nfs-exporter.
+# rustdesk_hbbr_args (string):            Set extra arguments to pass to nfs-exporter
+#               Default is "".
+# rustdesk_hbbr_user (string):            Set user that rustdesk_hbbr will run under
+#               Default is "root".
+# rustdesk_hbbr_group (string):           Set group that rustdesk_hbbr will run under
+#               Default is "wheel".
+. /etc/rc.subr
+
+name=rustdesk_hbbr
+desc="Rustdesk Relay Server"
+rcvar=rustdesk_hbbr_enable
+
+load_rc_config $name
+
+: ${rustdesk_hbbr_enable:=NO}
+: ${rustdesk_hbbr_args:=""}
+: ${rustdesk_hbbr_user:=rustdesk}
+: ${rustdesk_hbbr_group:=rustdesk}
+
+pidfile=/var/run/rustdesk_hbbr.pid
+command=/usr/sbin/daemon
+procname=/usr/local/sbin/hbbr
+rustdesk_hbbr_chdir="/var/lib/rustdesk-server/"
+rustdesk_hbbr_args="-k _"
+command_args="-f -p ${pidfile} /usr/bin/env ${procname} ${rustdesk_hbbr_args}"
+
+start_precmd=rustdesk_hbbr_startprecmd
+
+rustdesk_hbbr_startprecmd()
+{
+    if [ -e ${pidfile} ]; then
+        chown ${rustdesk_hbbr_user}:${rustdesk_hbbr_group} ${pidfile};
+    else
+        install -o ${rustdesk_hbbr_user} -g ${rustdesk_hbbr_group} /dev/null ${pidfile};
+    fi
+    if [ -e ${rustdesk_hbbr_chdir} ]; then
+        chown -R ${rustdesk_hbbr_user}:${rustdesk_hbbr_group} ${rustdesk_hbbr_chdir};
+        chmod -R 770 ${rustdesk_hbbr_chdir};
+    else
+        mkdir -m 7et nonu
+0 ${rustdesk_hbbr_chdir};
+        chown ${rustdesk_hbbr_user}:${rustdesk_hbbr_group} ${rustdesk_hbbr_chdir};
+    fi
+}

--- a/rcd/rustdesk-hbbs
+++ b/rcd/rustdesk-hbbs
@@ -1,0 +1,57 @@
+#!/bin/sh
+
+# PROVIDE: rustdesk_hbbs
+# REQUIRE: LOGIN
+# KEYWORD: shutdown
+#
+# Add the following lines to /etc/rc.conf.local or /etc/rc.conf
+# to enable this service:
+#
+# rustdesk_hbbs_enable (bool):            Set to NO by default.
+#               Set it to YES to enable nfs-exporter.
+# rustdesk_hbbs_args (string):            Set extra arguments to pass to nfs-exporter
+#               Default is "".
+# rustdesk_hbbs_user (string):            Set user that rustdesk_hbbs will run under
+#               Default is "root".
+# rustdesk_hbbs_group (string):           Set group that rustdesk_hbbs will run under
+#               Default is "wheel".
+
+. /etc/rc.subr
+
+name=rustdesk_hbbs
+desc="Rustdesk ID/Rendezvous Server"
+rcvar=rustdesk_hbbs_enable
+
+load_rc_config $name
+
+: ${rustdesk_hbbs_enable:=NO}
+: ${rustdesk_hbbs_args:=""}
+: ${rustdesk_hbbs_user:=rustdesk}
+: ${rustdesk_hbbs_group:=rustdesk}
+
+pidfile=/var/run/rustdesk_hbbs.pid
+command=/usr/sbin/daemon
+procname=/usr/local/sbin/hbbs
+rustdesk_hbbs_chdir="/var/lib/rustdesk-server/"
+rustdesk_hbbs_args="-r your.ip.add.ress -k _"
+command_args="-f -p ${pidfile} /usr/bin/env ${procname} ${rustdesk_hbbs_args}"
+
+start_precmd=rustdesk_hbbs_startprecmd
+
+rustdesk_hbbs_startprecmd()
+{
+    if [ -e ${pidfile} ]; then
+        chown ${rustdesk_hbbs_user}:${rustdesk_hbbs_group} ${pidfile};
+    else
+        install -o ${rustdesk_hbbs_user} -g ${rustdesk_hbbs_group} /dev/null ${pidfile};
+    fi
+    if [ -e ${rustdesk_hbbs_chdir} ]; then
+        chown -R ${rustdesk_hbbs_user}:${rustdesk_hbbs_group} ${rustdesk_hbbs_chdir};
+        chmod -R 770 ${rustdesk_hbbs_chdir};
+    else
+        mkdir -m 770 ${rustdesk_hbbs_chdir};
+        chown ${rustdesk_hbbs_user}:${rustdesk_hbbs_group} ${rustdesk_hbbs_chdir};
+    fi
+}
+
+run_rc_command "$1"


### PR DESCRIPTION
Working rcd scripts, tested on FreeBSD 13 with other different service users (added manually in /etc/rc.conf).
The default user/group set to rustdesk. Can be used in two way:
A. With specifying hubs & hubby user and group at the end of /etc/rc.conf for example:
rustdesk_hbbs_user=existing_service_user
rustdesk_hbbs_group=existing_service_group
...

B. The default user need to be created with a command like:
pw adduser rustdesk -d /nonexistent -s /usr/sbin/nologin -c "Rustdesk Server user"

If can be put In the rcd scripts too, but it should be placed & handled more in and overall install script, or native package scripts 

Works both ways.