### PR TITLE
Update build.yaml - adding FreeBSD build

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -35,6 +35,7 @@ jobs:
           - { name: "arm64v8", target: "aarch64-unknown-linux-musl" }
           - { name: "armv7",   target: "armv7-unknown-linux-musleabihf" }
           - { name: "i386",    target: "i686-unknown-linux-musl" }
+          - { name: "amd64fb",    target: "x86_64-unknown-freebsd" }
 
     steps:
       
@@ -174,8 +175,9 @@ jobs:
           - { os: "linux", name: "arm64v8" }
           - { os: "linux", name: "armv7" }
           - { os: "linux", name: "i386" }
+          - { os: "linux", name: "amd64fb" }
           - { os: "windows", name: "x86_64" }
-
+          
     steps:
 
       - name: Download binaries (${{ matrix.job.os }} - ${{ matrix.job.name }})


### PR DESCRIPTION
After some discussions in Issue #209 , got the direction to turn directly to the workflow -> build process.

Reading about the Actions, it seemed logical to put the new os/arc build in the matrix to the end, but in the GitHub release part before the windows build.