### PR TITLE
Adding log capability over syslog

### DIFF
--- a/rcd/rustdesk-hbbr
+++ b/rcd/rustdesk-hbbr
@@ -35,6 +35,8 @@ procname=/usr/local/sbin/hbbr
 rustdesk_hbbr_chdir="/var/lib/rustdesk-server/"
 rustdesk_hbbr_args="-k _"
 command_args="-p ${pidfile} -o /var/log/rustdesk-hbbr.log ${procname} ${rustdesk_hbbr_args}"
+## If you want the daemon do its log over syslog comment out the above line and remove the comment from the below replacement
+#command_args="-p ${pidfile} -T ${name} ${procname} ${rustdesk_hbbr_args}"
 
 start_precmd=rustdesk_hbbr_startprecmd
 

--- a/rcd/rustdesk-hbbs
+++ b/rcd/rustdesk-hbbs
@@ -35,6 +35,8 @@ procname=/usr/local/sbin/hbbs
 rustdesk_hbbs_chdir="/var/lib/rustdesk-server/"
 rustdesk_hbbs_args="-r 130.255.77.37 -k _"
 command_args="-p ${pidfile} -o /var/log/rustdesk-hbbs.log ${procname} ${rustdesk_hbbs_args}"
+## If you want the daemon do its log over syslog comment out the above line and remove the comment from the below replacement
+#command_args="-p ${pidfile} -T ${name} ${procname} ${rustdesk_hbbs_args}"
 
 start_precmd=rustdesk_hbbs_startprecmd
 

--- a/rcd/rustdesk-hbbs
+++ b/rcd/rustdesk-hbbs
@@ -33,7 +33,7 @@ pidfile=/var/run/rustdesk_hbbs.pid
 command=/usr/sbin/daemon
 procname=/usr/local/sbin/hbbs
 rustdesk_hbbs_chdir="/var/lib/rustdesk-server/"
-rustdesk_hbbs_args="-r 130.255.77.37 -k _"
+rustdesk_hbbs_args="-r your.ip.add.ress -k _"
 command_args="-p ${pidfile} -o /var/log/rustdesk-hbbs.log ${procname} ${rustdesk_hbbs_args}"
 ## If you want the daemon do its log over syslog comment out the above line and remove the comment from the below replacement
 #command_args="-p ${pidfile} -T ${name} ${procname} ${rustdesk_hbbs_args}"


### PR DESCRIPTION
Logging over syslog added via a semi-duplicate line commented out by default. Instructions in the line above.