### PR TITLE
Move from Ubuntu 18.04 VM (Github Actions)

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -26,7 +26,7 @@ jobs:
   build:
 
     name: Build - ${{ matrix.job.name }}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-18.04
     strategy:
       fail-fast: false
       matrix:
@@ -45,7 +45,7 @@ jobs:
       - name: Install toolchain
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: "1.68"
+          toolchain: "1.67.1"
           override: true
           default: true
           components: rustfmt
@@ -166,7 +166,7 @@ jobs:
     needs: 
       - build
       - build-win
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-18.04
     strategy:
       fail-fast: false
       matrix:
@@ -206,7 +206,7 @@ jobs:
 
     name: Docker push - ${{ matrix.job.name }}
     needs: build
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-18.04
     strategy:
       fail-fast: false
       matrix:
@@ -276,7 +276,7 @@ jobs:
 
     name: Docker manifest
     needs: docker
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-18.04
 
     steps:
 
@@ -328,7 +328,7 @@ jobs:
 
     name: Docker push classic - ${{ matrix.job.name }}
     needs: build
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-18.04
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -26,7 +26,7 @@ jobs:
   build:
 
     name: Build - ${{ matrix.job.name }}
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:
@@ -45,7 +45,7 @@ jobs:
       - name: Install toolchain
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: "1.62"
+          toolchain: "1.68"
           override: true
           default: true
           components: rustfmt
@@ -166,7 +166,7 @@ jobs:
     needs: 
       - build
       - build-win
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
       matrix:
@@ -206,7 +206,7 @@ jobs:
 
     name: Docker push - ${{ matrix.job.name }}
     needs: build
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:
@@ -276,7 +276,7 @@ jobs:
 
     name: Docker manifest
     needs: docker
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
 
     steps:
 
@@ -328,7 +328,7 @@ jobs:
 
     name: Docker push classic - ${{ matrix.job.name }}
     needs: build
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Based on https://github.blog/changelog/2022-08-09-github-actions-the-ubuntu-18-04-actions-runner-image-is-being-deprecated-and-will-be-removed-by-12-1-22/, the 18.04 will be deprecated soon. Also moving toolchain to 1.68 to hopefully fix auto-build's FreeBSD release core dump issue.