### PR TITLE
Core dump fix and rc.d scripts optimisation for FreeBSD

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ tungstenite = "0.17"
 regex = "1.4"
 tower-http = { version = "0.3", features = ["fs", "trace", "cors"] }
 http = "0.2"
-flexi_logger = { version = "0.22", features = ["async", "use_chrono_for_offset"] }
+flexi_logger = { version = "0.22", features = ["async", "use_chrono_for_offset", "dont_minimize_extra_stacks"] }
 ipnetwork = "0.20"
 local-ip-address = "0.5.1"
 dns-lookup = "1.0.8"

--- a/rcd/rustdesk-hbbr
+++ b/rcd/rustdesk-hbbr
@@ -25,7 +25,7 @@ rcvar=rustdesk_hbbr_enable
 load_rc_config $name
 
 : ${rustdesk_hbbr_enable:=NO}
-: ${rustdesk_hbbr_args:=""}
+: ${rustdesk_hbbr_args="-k _"}
 : ${rustdesk_hbbr_user:=rustdesk}
 : ${rustdesk_hbbr_group:=rustdesk}
 
@@ -33,7 +33,6 @@ pidfile=/var/run/rustdesk_hbbr.pid
 command=/usr/sbin/daemon
 procname=/usr/local/sbin/hbbr
 rustdesk_hbbr_chdir="/var/lib/rustdesk-server/"
-rustdesk_hbbr_args="-k _"
 command_args="-p ${pidfile} -o /var/log/rustdesk-hbbr.log ${procname} ${rustdesk_hbbr_args}"
 ## If you want the daemon do its log over syslog comment out the above line and remove the comment from the below replacement
 #command_args="-p ${pidfile} -T ${name} ${procname} ${rustdesk_hbbr_args}"

--- a/rcd/rustdesk-hbbs
+++ b/rcd/rustdesk-hbbs
@@ -25,7 +25,8 @@ rcvar=rustdesk_hbbs_enable
 load_rc_config $name
 
 : ${rustdesk_hbbs_enable:=NO}
-: ${rustdesk_hbbs_args:=""}
+: ${rustdesk_hbbs_ip:=127.0.0.1}
+: ${rustdesk_hbbs_args="-r ${rustdesk_hbbs_ip} -k _"}
 : ${rustdesk_hbbs_user:=rustdesk}
 : ${rustdesk_hbbs_group:=rustdesk}
 
@@ -33,7 +34,6 @@ pidfile=/var/run/rustdesk_hbbs.pid
 command=/usr/sbin/daemon
 procname=/usr/local/sbin/hbbs
 rustdesk_hbbs_chdir="/var/lib/rustdesk-server/"
-rustdesk_hbbs_args="-r your.ip.add.ress -k _"
 command_args="-p ${pidfile} -o /var/log/rustdesk-hbbs.log ${procname} ${rustdesk_hbbs_args}"
 ## If you want the daemon do its log over syslog comment out the above line and remove the comment from the below replacement
 #command_args="-p ${pidfile} -T ${name} ${procname} ${rustdesk_hbbs_args}"


### PR DESCRIPTION
3 commits
- Core dump fix with (the possible) root cause Flexi_logger options for async writemode https://github.com/rustdesk/rustdesk-server/pull/232#issuecomment-1491347232
- removing need to edit rc.d scripts before use, necessary variables can be set over /etc/rc.conf, default IP set to 127.0.0.1 based on Freshport changes