### PR TITLE
Fix no direct connection when both peers on LAN

### DIFF
--- a/src/rendezvous_server.rs
+++ b/src/rendezvous_server.rs
@@ -706,17 +706,14 @@ impl RendezvousServer {
                 }
                 ph.nat_type = NatType::SYMMETRIC.into(); // will force relay
             }
-            let same_intranet = !ws
-                && match peer_addr {
-                    SocketAddr::V4(a) => match addr {
-                        SocketAddr::V4(b) => a.ip() == b.ip(),
+            let same_intranet: bool = !ws
+                && (peer_is_lan && is_lan || {
+                    match (peer_addr, addr) {
+                        (SocketAddr::V4(a), SocketAddr::V4(b)) => a.ip() == b.ip(),
+                        (SocketAddr::V6(a), SocketAddr::V6(b)) => a.ip() == b.ip(),
                         _ => false,
-                    },
-                    SocketAddr::V6(a) => match addr {
-                        SocketAddr::V6(b) => a.ip() == b.ip(),
-                        _ => false,
-                    },
-                };
+                    }
+                });
             let socket_addr = AddrMangle::encode(addr).into();
             if same_intranet {
                 log::debug!(

--- a/src/rendezvous_server.rs
+++ b/src/rendezvous_server.rs
@@ -1188,8 +1188,16 @@ impl RendezvousServer {
     #[inline]
     fn is_lan(&self, addr: SocketAddr) -> bool {
         if let Some(network) = &self.inner.mask {
-            if let SocketAddr::V4(addr) = addr {
-                return network.contains(*addr.ip());
+            match addr {
+                SocketAddr::V4(v4_socket_addr) => {
+                    return network.contains(*v4_socket_addr.ip());
+                }
+                
+                SocketAddr::V6(v6_socket_addr) => {
+                    if let Some(v4_addr) = v6_socket_addr.ip().to_ipv4_mapped() {
+                        return network.contains(v4_addr);
+                    }
+                }
             }
         }
         false


### PR DESCRIPTION
We had multiple peers all connecting via VPN to a network that was hosting the rendezvous and relay servers. However none of the peers were able to establish a direct connection, even though they had no trouble using direct IP access. Having set `--mask` to `10.0.0.0/8` made no difference.

After some debugging, we found that `is_lan()` was returning false for any of our peers' IP addresses, even though these peers were using IPs that were well within the network we specified using `--mask`. Turns out, our IPv4 addresses were noted as [IPv4-mapped IPv6 addresses](https://doc.rust-lang.org/std/net/struct.Ipv6Addr.html#ipv4-mapped-ipv6-addresses) (i.e. `::ffff:10.50.55.22`). `is_lan()` has been improved to take these type of addresses into account.

Further more, the calculation of the boolean `same_intranet` seemed to only switch to `true` if both peers were using the same IP address. This has been improved to switch to `true` in the case where both peers fall within the network passed by `--mask`.

With these changes, our peers are now able to successfully establish a secured direct connection to one another.