### PR TITLE
FreeBSD rc scripts fixes

### DIFF
--- a/rcd/rustdesk-hbbr
+++ b/rcd/rustdesk-hbbr
@@ -8,9 +8,9 @@
 # to enable this service:
 #
 # rustdesk_hbbr_enable (bool):            Set to NO by default.
-#               Set it to YES to enable nfs-exporter.
-# rustdesk_hbbr_args (string):            Set extra arguments to pass to nfs-exporter
-#               Default is "".
+#               Set it to YES to enable rustdesk_hbbr.
+# rustdesk_hbbr_args (string):            Set extra arguments to pass to rustdesk_hbbr
+#               Default is "-k _".
 # rustdesk_hbbr_user (string):            Set user that rustdesk_hbbr will run under
 #               Default is "root".
 # rustdesk_hbbr_group (string):           Set group that rustdesk_hbbr will run under

--- a/rcd/rustdesk-hbbr
+++ b/rcd/rustdesk-hbbr
@@ -32,7 +32,7 @@ load_rc_config $name
 pidfile=/var/run/rustdesk_hbbr.pid
 command=/usr/sbin/daemon
 procname=/usr/local/sbin/hbbr
-rustdesk_hbbr_chdir="/var/lib/rustdesk-server/"
+rustdesk_hbbr_chdir=/var/lib/rustdesk-server
 command_args="-p ${pidfile} -o /var/log/rustdesk-hbbr.log ${procname} ${rustdesk_hbbr_args}"
 ## If you want the daemon do its log over syslog comment out the above line and remove the comment from the below replacement
 #command_args="-p ${pidfile} -T ${name} ${procname} ${rustdesk_hbbr_args}"

--- a/rcd/rustdesk-hbbr
+++ b/rcd/rustdesk-hbbr
@@ -32,7 +32,7 @@ load_rc_config $name
 pidfile=/var/run/rustdesk_hbbr.pid
 command=/usr/sbin/daemon
 procname=/usr/local/sbin/hbbr
-rustdesk_hbbr_chdir=/var/lib/rustdesk-server
+rustdesk_hbbr_chdir=/var/db/rustdesk-server
 command_args="-p ${pidfile} -o /var/log/rustdesk-hbbr.log ${procname} ${rustdesk_hbbr_args}"
 ## If you want the daemon do its log over syslog comment out the above line and remove the comment from the below replacement
 #command_args="-p ${pidfile} -T ${name} ${procname} ${rustdesk_hbbr_args}"

--- a/rcd/rustdesk-hbbs
+++ b/rcd/rustdesk-hbbs
@@ -33,7 +33,7 @@ load_rc_config $name
 pidfile=/var/run/rustdesk_hbbs.pid
 command=/usr/sbin/daemon
 procname=/usr/local/sbin/hbbs
-rustdesk_hbbs_chdir="/var/lib/rustdesk-server/"
+rustdesk_hbbs_chdir=/var/lib/rustdesk-server
 command_args="-p ${pidfile} -o /var/log/rustdesk-hbbs.log ${procname} ${rustdesk_hbbs_args}"
 ## If you want the daemon do its log over syslog comment out the above line and remove the comment from the below replacement
 #command_args="-p ${pidfile} -T ${name} ${procname} ${rustdesk_hbbs_args}"

--- a/rcd/rustdesk-hbbs
+++ b/rcd/rustdesk-hbbs
@@ -33,7 +33,7 @@ load_rc_config $name
 pidfile=/var/run/rustdesk_hbbs.pid
 command=/usr/sbin/daemon
 procname=/usr/local/sbin/hbbs
-rustdesk_hbbs_chdir=/var/lib/rustdesk-server
+rustdesk_hbbs_chdir=/var/db/rustdesk-server
 command_args="-p ${pidfile} -o /var/log/rustdesk-hbbs.log ${procname} ${rustdesk_hbbs_args}"
 ## If you want the daemon do its log over syslog comment out the above line and remove the comment from the below replacement
 #command_args="-p ${pidfile} -T ${name} ${procname} ${rustdesk_hbbs_args}"

--- a/rcd/rustdesk-hbbs
+++ b/rcd/rustdesk-hbbs
@@ -8,9 +8,9 @@
 # to enable this service:
 #
 # rustdesk_hbbs_enable (bool):            Set to NO by default.
-#               Set it to YES to enable nfs-exporter.
-# rustdesk_hbbs_args (string):            Set extra arguments to pass to nfs-exporter
-#               Default is "".
+#               Set it to YES to enable rustdesk_hbbs.
+# rustdesk_hbbs_args (string):            Set extra arguments to pass to rustdesk_hbbs
+#               Default is "-r ${rustdesk_hbbs_ip} -k _".
 # rustdesk_hbbs_user (string):            Set user that rustdesk_hbbs will run under
 #               Default is "root".
 # rustdesk_hbbs_group (string):           Set group that rustdesk_hbbs will run under


### PR DESCRIPTION
Here are some updates to the rc scripts:

- Some comments where wrong, with lines referencing nfs-exporter
- Updated the defaults for _args
- Quotes are unneeded around the _chdir variables, as long as the path does not include spaces
- Changed the chdir directory to /var/db, according to FreeBSD hier(7) man page.

Noticed while looking for a fix to #288 

