### PR TITLE
minimal docker classic images

### DIFF
--- a/docker-classic/Dockerfile
+++ b/docker-classic/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04    
+FROM scratch    
 COPY hbbs /usr/bin/hbbs    
 COPY hbbr /usr/bin/hbbr    
 WORKDIR /root 


### PR DESCRIPTION
I just realized that there's no need to have a full-blown ubuntu image if you're using only the hbbr/hbbs binaries.

This reduces the image size from ~100Mb to around 25Mb.