### PR TITLE
private key size check

### DIFF
--- a/src/rendezvous_server.rs
+++ b/src/rendezvous_server.rs
@@ -1174,6 +1174,9 @@ impl RendezvousServer {
                 let mut tmp = [0u8; sign::SECRETKEYBYTES];
                 tmp[..].copy_from_slice(&sk);
                 out_sk = Some(sign::SecretKey(tmp));
+            } else {
+                log::error!("Malformed private key");
+                std::process::exit(1);
             }
         }
 


### PR DESCRIPTION
throw an error and quit if the length of the secret key is incorrect.