### PR TITLE
Add description of relay server variable for clarity

### DIFF
--- a/rcd/rustdesk-hbbs
+++ b/rcd/rustdesk-hbbs
@@ -9,6 +9,8 @@
 #
 # rustdesk_hbbs_enable (bool):            Set to NO by default.
 #               Set it to YES to enable rustdesk_hbbs.
+# rustdesk_hbbs_ip (string):              Set IP address/hostname of relay server to use
+#               Defaults to "127.0.0.1", please replace with your server hostname/IP.
 # rustdesk_hbbs_args (string):            Set extra arguments to pass to rustdesk_hbbs
 #               Default is "-r ${rustdesk_hbbs_ip} -k _".
 # rustdesk_hbbs_user (string):            Set user that rustdesk_hbbs will run under


### PR DESCRIPTION
Since the "rustdesk_hbbs_ip" is not where the server should listen on, but actually the relay server to use, I added a description that will clarify this