### PR TITLE
ipv6 potential fix

### DIFF
--- a/libs/hbb_common/src/tcp.rs
+++ b/libs/hbb_common/src/tcp.rs
@@ -282,8 +282,10 @@ pub async fn listen_any(port: u16) -> ResultType<TcpListener> {
             .bind(SocketAddr::new(IpAddr::V6(Ipv6Addr::UNSPECIFIED), port))
             .is_ok()
         {
-            if let Ok(l) = socket.listen(DEFAULT_BACKLOG) {
-                return Ok(l);
+            if let Ok(_l) = socket.listen(DEFAULT_BACKLOG) {
+            /*
+               return Ok(l);
+            */
             }
         }
     }

--- a/src/rendezvous_server.rs
+++ b/src/rendezvous_server.rs
@@ -1296,7 +1296,7 @@ async fn create_udp_listener(port: i32, rmem: usize) -> ResultType<FramedSocket>
     let addr = SocketAddr::new(IpAddr::V6(Ipv6Addr::UNSPECIFIED), port as _);
     if let Ok(s) = FramedSocket::new_reuse(&addr, false, rmem).await {
         log::debug!("listen on udp {:?}", s.local_addr());
-        return Ok(s);
+    //    return Ok(s);
     }
     let addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), port as _);
     let s = FramedSocket::new_reuse(&addr, false, rmem).await?;


### PR DESCRIPTION
This pull request is about fixing a problem in the open source version of rustdesk-server when run on a bare metal linux server. The problem  manifests itself as the rendezvous server only listening on ipv6 ports. My lack of knowledge of the rust programming language means that while this pull request will build. However the rendezvous will fail connection requests with the following trace.
```
[2024-04-01 12:38:53.722551 +01:00] TRACE [/home/roger/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-tungstenite-0.17.1/src/handshake.rs:157] Setting context in handshake
[2024-04-01 12:38:53.722641 +01:00] TRACE [/home/roger/.cargo/registry/src/github.com-1ecc6299db9ec823/tungstenite-0.17.2/src/handshake/machine.rs:40] Doing handshake round.
[2024-04-01 12:38:53.722694 +01:00] TRACE [/home/roger/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-tungstenite-0.17.1/src/compat.rs:149] /home/roger/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-tungstenite-0.17.1/src/compat.rs:149 Read.read
[2024-04-01 12:38:53.723568 +01:00] TRACE [/home/roger/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-tungstenite-0.17.1/src/compat.rs:126] /home/roger/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-tungstenite-0.17.1/src/compat.rs:126 AllowStd.with_context
[2024-04-01 12:38:53.723651 +01:00] TRACE [/home/roger/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-tungstenite-0.17.1/src/compat.rs:152] /home/roger/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-tungstenite-0.17.1/src/compat.rs:152 Read.with_context read -> poll_read
[2024-04-01 12:38:53.723728 +01:00] TRACE [/home/roger/.cargo/registry/src/github.com-1ecc6299db9ec823/mio-0.8.3/src/poll.rs:630] deregistering event source from poller
[2024-04-01 12:38:53.723859 +01:00] DEBUG [src/rendezvous_server.rs:1101] WebSocket protocol error: httparse error: invalid token

Caused by:
    0: httparse error: invalid token
    1: invalid token, hbbs::rendezvous_server:src/rendezvous_server.rs:1101:13
```
If only the patch in src/rendezvous_server.rs is applied then listening ports will be open on both ipv4 and ipv6. If the patch in libs/hbb_common/src/tcp.rs is applied as well then no ipv6 ports will be created at on either the rendezvous server or the relay server.

Please can this pull request be reviewed by someone who is familiar with rustdesk-server code.