### PR TITLE
docs: the servers are by comma instead of colon

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -17,9 +17,9 @@ fn main() -> ResultType<()> {
         "-c --config=[FILE] +takes_value 'Sets a custom config file'
         -p, --port=[NUMBER(default={RENDEZVOUS_PORT})] 'Sets the listening port'
         -s, --serial=[NUMBER(default=0)] 'Sets configure update serial number'
-        -R, --rendezvous-servers=[HOSTS] 'Sets rendezvous servers, separated by colon'
+        -R, --rendezvous-servers=[HOSTS] 'Sets rendezvous servers, separated by comma'
         -u, --software-url=[URL] 'Sets download url of RustDesk software of newest version'
-        -r, --relay-servers=[HOST] 'Sets the default relay servers, separated by colon'
+        -r, --relay-servers=[HOST] 'Sets the default relay servers, separated by comma'
         -M, --rmem=[NUMBER(default={RMEM})] 'Sets UDP recv buffer size, set system rmem_max first, e.g., sudo sysctl -w net.core.rmem_max=52428800. vi /etc/sysctl.conf, net.core.rmem_max=52428800, sudo sysctl –p'
         , --mask=[MASK] 'Determine if the connection comes from LAN, e.g. 192.168.0.0/16'
         -k, --key=[KEY] 'Only allow the client with the same key'",


### PR DESCRIPTION
Based on the code at https://github.com/rustdesk/rustdesk-server/blob/master/src/common.rs#L42 