### PR TITLE
Bump s6-overlay to v3.2.0.0 and fix env warnings

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,6 +1,6 @@
 FROM busybox:stable
 
-ARG S6_OVERLAY_VERSION=3.1.1.2
+ARG S6_OVERLAY_VERSION=3.2.0.0
 ARG S6_ARCH=x86_64
 ADD https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-noarch.tar.xz /tmp
 ADD https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-${S6_ARCH}.tar.xz /tmp
@@ -12,8 +12,8 @@ RUN \
 
 COPY rootfs /
 
-ENV RELAY relay.example.com
-ENV ENCRYPTED_ONLY 0
+ENV RELAY=relay.example.com
+ENV ENCRYPTED_ONLY=0
 
 EXPOSE 21115 21116 21116/udp 21117 21118 21119
 


### PR DESCRIPTION
* Bump s6-overlay to [v3.2.0.0](https://github.com/just-containers/s6-overlay/releases/tag/v3.2.0.0).
* Fix `LegacyKeyValueFormat` warnings

Error will shown while building:
```
 2 warnings found (use docker --debug to expand):
 - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 15)
 - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 16)
```

Solution: Add `=` between env name and value
```dockerfile
ENV RELAY=relay.example.com
ENV ENCRYPTED_ONLY=0
```