### PR TITLE
feat: Publish container images to GitHub ghcr.io

### DIFF
--- a/.github/workflows/ghcr.yml
+++ b/.github/workflows/ghcr.yml
@@ -37,7 +37,7 @@ jobs:
     steps:
 
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4.2.0
 
       - name: Install toolchain
         uses: actions-rs/toolchain@v1
@@ -68,7 +68,8 @@ jobs:
             target/${{ matrix.job.target }}/release/hbbs
             target/${{ matrix.job.target }}/release/rustdesk-utils
           if-no-files-found: error
-
+  
+  # S6 Version
   # Build and push single-arch Docker images to ghcr.io
   docker:
 
@@ -91,10 +92,10 @@ jobs:
     steps:
 
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4.2.0
         
       - name: Download binaries
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4.1.8
         with:
           name: binaries-linux-${{ matrix.job.name }}
           path: docker/rootfs/usr/bin
@@ -103,14 +104,14 @@ jobs:
         run: chmod -v a+x docker/rootfs/usr/bin/*
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v3.2.0
       
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3.6.1
 
       - name: Log in to GitHub Container Registry
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3.3.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -118,7 +119,7 @@ jobs:
         
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@v5.5.1
         with:
           images: ghcr.io/${{ github.repository }}-s6
 
@@ -131,7 +132,7 @@ jobs:
           echo "MAJOR_TAG=$M" >> $GITHUB_ENV
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6.8.0
         with:
           context: "./docker"
           platforms: ${{ matrix.job.docker_platform }}
@@ -144,8 +145,6 @@ jobs:
             ghcr.io/${{ github.repository }}-s6:${{ env.GIT_TAG }}-${{ matrix.job.name }}
             ghcr.io/${{ github.repository }}-s6:${{ env.MAJOR_TAG }}-${{ matrix.job.name }}
           labels: ${{ steps.meta.outputs.labels }}
-          annotations: |
-            org.opencontainers.image.description=Your Image Description Here
 
   # Build and push multi-arch Docker images to ghcr.io
   docker-manifest:
@@ -160,20 +159,9 @@ jobs:
 
     steps:
 
-      - name: Checkout
-        uses: actions/checkout@v3
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-        with:
-          driver: docker-container
-
       - name: Log in to GitHub Container Registry
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3.3.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -187,47 +175,158 @@ jobs:
           echo "GIT_TAG=$T" >> $GITHUB_ENV
           echo "MAJOR_TAG=$M" >> $GITHUB_ENV
 
+      # Create and push manifest for :ve.rs.ion tag
       - name: Create and push manifest (:ve.rs.ion)
-        uses: docker/build-push-action@v5
+        uses: Noelware/docker-manifest-action@v0.4.2
+        if: github.event_name != 'workflow_dispatch'
         with:
-          push: true
-          provenance: false
-          platforms: linux/amd64,linux/arm64,linux/arm/v7,linux/386
-          tags: ghcr.io/${{ github.repository }}-s6:${{ env.GIT_TAG }}
-          labels: |
-            org.opencontainers.image.description=Your Image Description Here
-          manifests: |
+          base-image: ghcr.io/${{ github.repository }}-s6:${{ env.GIT_TAG }}
+          extra-images: |
             ghcr.io/${{ github.repository }}-s6:${{ env.GIT_TAG }}-amd64,
             ghcr.io/${{ github.repository }}-s6:${{ env.GIT_TAG }}-arm64v8,
             ghcr.io/${{ github.repository }}-s6:${{ env.GIT_TAG }}-armv7,
             ghcr.io/${{ github.repository }}-s6:${{ env.GIT_TAG }}-i386
-
-      - name: Create and push manifest (:major)
-        uses: docker/build-push-action@v5
-        with:
           push: true
-          provenance: false
-          platforms: linux/amd64,linux/arm64,linux/arm/v7,linux/386
-          tags: ghcr.io/${{ github.repository }}-s6:${{ env.MAJOR_TAG }}
-          labels: |
-            org.opencontainers.image.description=Your Image Description Here
-          manifests: |
-            ghcr.io/${{ github.repository }}-s6:${{ env.MAJOR_TAG }}-amd64,
-            ghcr.io/${{ github.repository }}-s6:${{ env.MAJOR_TAG }}-arm64v8,
-            ghcr.io/${{ github.repository }}-s6:${{ env.MAJOR_TAG }}-armv7,
-            ghcr.io/${{ github.repository }}-s6:${{ env.MAJOR_TAG }}-i386
 
+      # Create and push manifest for :latest tag
       - name: Create and push manifest (:latest)
-        uses: docker/build-push-action@v5
+        uses: Noelware/docker-manifest-action@v0.4.2
         with:
-          push: true
-          provenance: false
-          platforms: linux/amd64,linux/arm64,linux/arm/v7,linux/386
-          tags: ghcr.io/${{ github.repository }}-s6:${{ env.LATEST_TAG }}
-          labels: |
-            org.opencontainers.image.description=Your Image Description Here
-          manifests: |
+          base-image: ghcr.io/${{ github.repository }}-s6:${{ env.LATEST_TAG }}
+          extra-images: |
             ghcr.io/${{ github.repository }}-s6:${{ env.LATEST_TAG }}-amd64,
             ghcr.io/${{ github.repository }}-s6:${{ env.LATEST_TAG }}-arm64v8,
             ghcr.io/${{ github.repository }}-s6:${{ env.LATEST_TAG }}-armv7,
             ghcr.io/${{ github.repository }}-s6:${{ env.LATEST_TAG }}-i386
+          push: true
+
+
+
+  # Classic Version
+  # Build and push single-arch Docker images to ghcr.io
+  docker-classic:
+
+    name: Docker push - ${{ matrix.job.name }}
+    needs: build
+    runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix:
+        job:
+          - { name: "amd64",   docker_platform: "linux/amd64",  s6_platform: "x86_64" }
+          - { name: "arm64v8", docker_platform: "linux/arm64",  s6_platform: "aarch64" }
+          - { name: "armv7",   docker_platform: "linux/arm/v7", s6_platform: "armhf" }
+          - { name: "i386",    docker_platform: "linux/386",    s6_platform: "i686" }
+
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+
+      - name: Checkout
+        uses: actions/checkout@v4.2.0
+        
+      - name: Download binaries
+        uses: actions/download-artifact@v4.1.8
+        with:
+          name: binaries-linux-${{ matrix.job.name }}
+          path: docker/rootfs/usr/bin
+
+      - name: Make binaries executable
+        run: chmod -v a+x docker/rootfs/usr/bin/*
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3.2.0
+      
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3.6.1
+
+      - name: Log in to GitHub Container Registry
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3.3.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+        
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5.5.1
+        with:
+          images: ghcr.io/${{ github.repository }}
+
+      - name: Get git tag
+        id: vars
+        run: |
+          T=${GITHUB_REF#refs/*/}
+          M=${T%%.*}
+          echo "GIT_TAG=$T" >> $GITHUB_ENV
+          echo "MAJOR_TAG=$M" >> $GITHUB_ENV
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6.8.0
+        with:
+          context: "./docker-classic"
+          platforms: ${{ matrix.job.docker_platform }}
+          push: true
+          provenance: false
+          tags: |
+            ghcr.io/${{ github.repository }}-s6:${{ env.LATEST_TAG }}-${{ matrix.job.name }}
+            ghcr.io/${{ github.repository }}-s6:${{ env.GIT_TAG }}-${{ matrix.job.name }}
+            ghcr.io/${{ github.repository }}-s6:${{ env.MAJOR_TAG }}-${{ matrix.job.name }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+  # Build and push multi-arch Docker images to ghcr.io
+  docker-classic-manifest:
+
+    name: Docker manifest
+    needs: docker-classic
+    runs-on: ubuntu-24.04
+
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+
+      - name: Log in to GitHub Container Registry
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3.3.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Get git tag
+        id: vars
+        run: |
+          T=${GITHUB_REF#refs/*/}
+          M=${T%%.*}
+          echo "GIT_TAG=$T" >> $GITHUB_ENV
+          echo "MAJOR_TAG=$M" >> $GITHUB_ENV
+
+      # Create and push manifest for :ve.rs.ion tag
+      - name: Create and push manifest (:ve.rs.ion)
+        uses: Noelware/docker-manifest-action@v0.4.2
+        if: github.event_name != 'workflow_dispatch'
+        with:
+          base-image: ghcr.io/${{ github.repository }}-s6:${{ env.GIT_TAG }}
+          extra-images: |
+            ghcr.io/${{ github.repository }}-s6:${{ env.GIT_TAG }}-amd64,
+            ghcr.io/${{ github.repository }}-s6:${{ env.GIT_TAG }}-arm64v8,
+            ghcr.io/${{ github.repository }}-s6:${{ env.GIT_TAG }}-armv7,
+            ghcr.io/${{ github.repository }}-s6:${{ env.GIT_TAG }}-i386
+          push: true
+
+      # Create and push manifest for :latest tag
+      - name: Create and push manifest (:latest)
+        uses: Noelware/docker-manifest-action@v0.4.2
+        with:
+          base-image: ghcr.io/${{ github.repository }}-s6:${{ env.LATEST_TAG }}
+          extra-images: |
+            ghcr.io/${{ github.repository }}-s6:${{ env.LATEST_TAG }}-amd64,
+            ghcr.io/${{ github.repository }}-s6:${{ env.LATEST_TAG }}-arm64v8,
+            ghcr.io/${{ github.repository }}-s6:${{ env.LATEST_TAG }}-armv7,
+            ghcr.io/${{ github.repository }}-s6:${{ env.LATEST_TAG }}-i386
+          push: true

--- a/.github/workflows/ghcr.yml
+++ b/.github/workflows/ghcr.yml
@@ -1,4 +1,4 @@
-name: build ghcr
+name: Build and publish to ghcr.io
 
 on:
   workflow_dispatch:
@@ -81,7 +81,7 @@ jobs:
             target/${{ matrix.job.target }}/release/rustdesk-utils
         
   # Build and push single-arch Docker images to ghcr.io
-  docker:
+  create-s6-overlay-images:
 
     name: Docker push - ${{ matrix.job.name }}
     needs: build
@@ -164,10 +164,10 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
 
   # Build and push multi-arch Docker images to ghcr.io
-  docker-manifest:
+  create-s6-overlay-images-manifest:
 
-    name: Docker manifest
-    needs: docker
+    name: Manifest for s6-overlay images
+    needs: create-s6-overlay-images
     runs-on: ubuntu-24.04
 
     permissions:
@@ -229,14 +229,8 @@ jobs:
             ghcr.io/${{ github.repository }}-s6:${{ env.LATEST_TAG }}-i386
           push: true
 
-
-
-
-
-
-
   # Build and push single-arch Docker images to ghcr.io
-  docker-classic:
+  create-classic-images:
 
     name: Docker push - ${{ matrix.job.name }}
     needs: build
@@ -317,10 +311,10 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
 
   # Build and push multi-arch Docker images to ghcr.io
-  docker-classic-manifest:
+  create-classic-images-manifest:
 
-    name: Docker manifest
-    needs: docker-classic
+    name: Manifest for classic images
+    needs: create-classic-images
     runs-on: ubuntu-24.04
 
     permissions:

--- a/.github/workflows/ghcr.yml
+++ b/.github/workflows/ghcr.yml
@@ -1,0 +1,133 @@
+name: build
+
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+'
+      - '[0-9]+.[0-9]+.[0-9]+'
+      - 'v[0-9]+.[0-9]+.[0-9]+-[0-9]+'
+      - '[0-9]+.[0-9]+.[0-9]+-[0-9]+'
+
+env:
+  CARGO_TERM_COLOR: always
+  LATEST_TAG: latest
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+
+  # Binary build
+  build:
+
+    name: Build - ${{ matrix.job.name }}
+    runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix:
+        job:
+          - { name: "amd64",   target: "x86_64-unknown-linux-musl", docker_platform: "linux/amd64",  s6_platform: "x86_64" }
+          - { name: "arm64v8", target: "aarch64-unknown-linux-musl", docker_platform: "linux/arm64",  s6_platform: "aarch64" }
+          - { name: "armv7",   target: "armv7-unknown-linux-musleabihf", docker_platform: "linux/arm/v7", s6_platform: "armhf" }
+          - { name: "i386",    target: "i686-unknown-linux-musl", docker_platform: "linux/386",    s6_platform: "i686" }
+
+    steps:
+
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Install toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: "1.70.0"
+          override: true
+          default: true
+          components: rustfmt
+          profile: minimal
+          target: ${{ matrix.job.target }}
+
+      - name: Build
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --release --all-features --target=${{ matrix.job.target }}
+          use-cross: true  
+
+      - name: Exec chmod
+        run: chmod -v a+x target/${{ matrix.job.target }}/release/*
+
+      - name: Publish Artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: binaries-linux-${{ matrix.job.name }}
+          path: |
+            target/${{ matrix.job.target }}/release/hbbr
+            target/${{ matrix.job.target }}/release/hbbs
+            target/${{ matrix.job.target }}/release/rustdesk-utils
+          if-no-files-found: error
+
+  # Build and push multi-arch Docker images to ghcr.io with annotations
+  docker:
+
+    name: Docker Build and Push
+    needs: build
+    runs-on: ubuntu-24.04
+
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Download binaries
+        uses: actions/download-artifact@v3
+        with:
+          name: binaries-linux-*
+          path: docker/rootfs/usr/bin
+
+      - name: Make binaries executable
+        run: chmod -v a+x docker/rootfs/usr/bin/*
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Log in to GitHub Container Registry
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ghcr.io/${{ github.repository }}-s6
+          tags: |
+            type=ref,event=branch
+            type=raw,value=${{ env.LATEST_TAG }}
+            type=raw,value=${{ github.ref_name }}
+          labels: |
+            org.opencontainers.image.description="RustDesk Server s6-overlay image, running hbbs, hbbr at one container."
+
+      - name: Build and push Docker images
+        uses: docker/build-push-action@v5
+        with:
+          context: "./docker"
+          platforms: linux/amd64,linux/arm64,linux/arm/v7,linux/386
+          push: true
+          provenance: false
+          build-args: |
+            S6_ARCH=${{ matrix.job.s6_platform }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          annotations: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/ghcr.yml
+++ b/.github/workflows/ghcr.yml
@@ -74,13 +74,11 @@ jobs:
       - name: Publish Artifacts
         uses: actions/upload-artifact@v4
         with:
-            name: binaries-linux-${{ matrix.job.name }}
-            path:
-                - target/${{ matrix.job.target }}/release/hbbr
-                - target/${{ matrix.job.target }}/release/hbbs
-                - target/${{ matrix.job.target }}/release/rustdesk-utils
-            if-no-files-found: error
-        
+          name: binaries-linux-${{ matrix.job.name }}
+          path: |
+            target/${{ matrix.job.target }}/release/hbbr
+            target/${{ matrix.job.target }}/release/hbbs
+            target/${{ matrix.job.target }}/release/rustdesk-utils
         
   # Build and push single-arch Docker images to ghcr.io
   docker:

--- a/.github/workflows/ghcr.yml
+++ b/.github/workflows/ghcr.yml
@@ -21,7 +21,6 @@ jobs:
 
   # Binary build
   build:
-
     name: Build - ${{ matrix.job.name }}
     runs-on: ubuntu-24.04
     strategy:
@@ -35,7 +34,6 @@ jobs:
           #- { name: "amd64fb", target: "x86_64-unknown-freebsd" }
 
     steps:
-
       - name: Checkout
         uses: actions/checkout@v4
     
@@ -60,17 +58,6 @@ jobs:
       - name: Exec chmod
         run: chmod -v a+x target/${{ matrix.job.target }}/release/*
 
-      #- name: Publish Artifacts
-        #uses: actions/upload-artifact@v3
-        #with:
-          #name: binaries-linux-${{ matrix.job.name }}
-          #path: |
-            #target/${{ matrix.job.target }}/release/hbbr
-            #target/${{ matrix.job.target }}/release/hbbs
-            #target/${{ matrix.job.target }}/release/rustdesk-utils
-          #if-no-files-found: error
-
-
       - name: Publish Artifacts
         uses: actions/upload-artifact@v4
         with:
@@ -82,7 +69,6 @@ jobs:
         
   # Build and push single-arch Docker images to ghcr.io
   create-s6-overlay-images:
-
     name: Docker push - ${{ matrix.job.name }}
     needs: build
     runs-on: ubuntu-24.04
@@ -95,20 +81,9 @@ jobs:
           - { name: "armv7",   docker_platform: "linux/arm/v7", s6_platform: "armhf" }
           - { name: "i386",    docker_platform: "linux/386",    s6_platform: "i686" }
 
-    permissions:
-      contents: read
-      packages: write
-
     steps:
-
       - name: Checkout
         uses: actions/checkout@v4
-        
-      #- name: Download binaries
-        #uses: actions/download-artifact@v3
-        #with:
-          #name: binaries-linux-${{ matrix.job.name }}
-          #path: docker/rootfs/usr/bin
 
       - name: Download binaries
         uses: actions/download-artifact@v4
@@ -136,7 +111,7 @@ jobs:
         
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@v5
         with:
           images: ghcr.io/${{ github.repository }}-s6
 
@@ -149,7 +124,7 @@ jobs:
           echo "MAJOR_TAG=$M" >> $GITHUB_ENV
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           context: "./docker"
           platforms: ${{ matrix.job.docker_platform }}
@@ -163,19 +138,13 @@ jobs:
             ghcr.io/${{ github.repository }}-s6:${{ env.MAJOR_TAG }}-${{ matrix.job.name }}
           labels: ${{ steps.meta.outputs.labels }}
 
-  # Build and push multi-arch Docker images to ghcr.io
+  # Set up minifest and tag for pushed image
   create-s6-overlay-images-manifest:
-
     name: Manifest for s6-overlay images
     needs: create-s6-overlay-images
     runs-on: ubuntu-24.04
 
-    permissions:
-      contents: read
-      packages: write
-
     steps:
-
       - name: Log in to GitHub Container Registry
         if: github.event_name != 'pull_request'
         uses: docker/login-action@v3
@@ -231,7 +200,6 @@ jobs:
 
   # Build and push single-arch Docker images to ghcr.io
   create-classic-images:
-
     name: Docker push - ${{ matrix.job.name }}
     needs: build
     runs-on: ubuntu-24.04
@@ -244,20 +212,9 @@ jobs:
           - { name: "armv7",   docker_platform: "linux/arm/v7" }
           - { name: "i386",    docker_platform: "linux/386" }
 
-    permissions:
-      contents: read
-      packages: write
-
     steps:
-
       - name: Checkout
         uses: actions/checkout@v4
-        
-      #- name: Download binaries
-        #uses: actions/download-artifact@v3
-        #with:
-          #name: binaries-linux-${{ matrix.job.name }}
-          #path: docker/rootfs/usr/bin
 
       - name: Download binaries
         uses: actions/download-artifact@v4
@@ -285,7 +242,7 @@ jobs:
         
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@v5
         with:
           images: ghcr.io/${{ github.repository }}
 
@@ -298,7 +255,7 @@ jobs:
           echo "MAJOR_TAG=$M" >> $GITHUB_ENV
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           context: "./docker-classic"
           platforms: ${{ matrix.job.docker_platform }}
@@ -310,19 +267,13 @@ jobs:
             ghcr.io/${{ github.repository }}:${{ env.MAJOR_TAG }}-${{ matrix.job.name }}
           labels: ${{ steps.meta.outputs.labels }}
 
-  # Build and push multi-arch Docker images to ghcr.io
+  # Set up minifest and tag for pushed image
   create-classic-images-manifest:
-
     name: Manifest for classic images
     needs: create-classic-images
     runs-on: ubuntu-24.04
 
-    permissions:
-      contents: read
-      packages: write
-
     steps:
-
       - name: Log in to GitHub Container Registry
         if: github.event_name != 'pull_request'
         uses: docker/login-action@v3

--- a/.github/workflows/ghcr.yml
+++ b/.github/workflows/ghcr.yml
@@ -32,7 +32,7 @@ jobs:
           - { name: "arm64v8", target: "aarch64-unknown-linux-musl" }
           - { name: "armv7",   target: "armv7-unknown-linux-musleabihf" }
           - { name: "i386",    target: "i686-unknown-linux-musl" }
-          - { name: "amd64fb", target: "x86_64-unknown-freebsd" }
+          #- { name: "amd64fb", target: "x86_64-unknown-freebsd" }
 
     steps:
 
@@ -104,11 +104,18 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4.2.0
         
+      #- name: Download binaries
+        #uses: actions/download-artifact@v3
+        #with:
+          #name: binaries-linux-${{ matrix.job.name }}
+          #path: docker/rootfs/usr/bin
+
       - name: Download binaries
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
-          name: binaries-linux-${{ matrix.job.name }}
+          pattern: binaries-linux-${{ matrix.job.name }}
           path: docker/rootfs/usr/bin
+          merge-multiple: true
 
       - name: Make binaries executable
         run: chmod -v a+x docker/rootfs/usr/bin/*

--- a/.github/workflows/ghcr.yml
+++ b/.github/workflows/ghcr.yml
@@ -228,3 +228,156 @@ jobs:
             ghcr.io/${{ github.repository }}-s6:${{ env.LATEST_TAG }}-armv7,
             ghcr.io/${{ github.repository }}-s6:${{ env.LATEST_TAG }}-i386
           push: true
+
+
+
+
+
+
+
+  # Build and push single-arch Docker images to ghcr.io
+  docker-classic:
+
+    name: Docker push - ${{ matrix.job.name }}
+    needs: build
+    runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix:
+        job:
+          - { name: "amd64",   docker_platform: "linux/amd64" }
+          - { name: "arm64v8", docker_platform: "linux/arm64" }
+          - { name: "armv7",   docker_platform: "linux/arm/v7" }
+          - { name: "i386",    docker_platform: "linux/386" }
+
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+
+      - name: Checkout
+        uses: actions/checkout@v4
+        
+      #- name: Download binaries
+        #uses: actions/download-artifact@v3
+        #with:
+          #name: binaries-linux-${{ matrix.job.name }}
+          #path: docker/rootfs/usr/bin
+
+      - name: Download binaries
+        uses: actions/download-artifact@v4
+        with:
+          pattern: binaries-linux-${{ matrix.job.name }}
+          path: docker/rootfs/usr/bin
+          merge-multiple: true
+
+      - name: Make binaries executable
+        run: chmod -v a+x docker/rootfs/usr/bin/*
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+        
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ghcr.io/${{ github.repository }}
+
+      - name: Get git tag
+        id: vars
+        run: |
+          T=${GITHUB_REF#refs/*/}
+          M=${T%%.*}
+          echo "GIT_TAG=$T" >> $GITHUB_ENV
+          echo "MAJOR_TAG=$M" >> $GITHUB_ENV
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: "./docker-classic"
+          platforms: ${{ matrix.job.docker_platform }}
+          push: true
+          provenance: false
+          tags: |
+            ghcr.io/${{ github.repository }}:${{ env.LATEST_TAG }}-${{ matrix.job.name }}
+            ghcr.io/${{ github.repository }}:${{ env.GIT_TAG }}-${{ matrix.job.name }}
+            ghcr.io/${{ github.repository }}:${{ env.MAJOR_TAG }}-${{ matrix.job.name }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+  # Build and push multi-arch Docker images to ghcr.io
+  docker-classic-manifest:
+
+    name: Docker manifest
+    needs: docker-classic
+    runs-on: ubuntu-24.04
+
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+
+      - name: Log in to GitHub Container Registry
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Get git tag
+        id: vars
+        run: |
+          T=${GITHUB_REF#refs/*/}
+          M=${T%%.*}
+          echo "GIT_TAG=$T" >> $GITHUB_ENV
+          echo "MAJOR_TAG=$M" >> $GITHUB_ENV
+
+      # Create and push manifest for :ve.rs.ion tag
+      - name: Create and push manifest (:ve.rs.ion)
+        uses: Noelware/docker-manifest-action@master
+        if: github.event_name != 'workflow_dispatch'
+        with:
+          base-image: ghcr.io/${{ github.repository }}:${{ env.GIT_TAG }}
+          extra-images: |
+            ghcr.io/${{ github.repository }}:${{ env.GIT_TAG }}-amd64,
+            ghcr.io/${{ github.repository }}:${{ env.GIT_TAG }}-arm64v8,
+            ghcr.io/${{ github.repository }}:${{ env.GIT_TAG }}-armv7,
+            ghcr.io/${{ github.repository }}:${{ env.GIT_TAG }}-i386
+          push: true
+
+      # Create and push manifest for :major tag
+      - name: Create and push manifest (:major)
+        uses: Noelware/docker-manifest-action@master
+        with:
+          base-image: ghcr.io/${{ github.repository }}:${{ env.MAJOR_TAG }}
+          extra-images: |
+            ghcr.io/${{ github.repository }}:${{ env.MAJOR_TAG }}-amd64,
+            ghcr.io/${{ github.repository }}:${{ env.MAJOR_TAG }}-arm64v8,
+            ghcr.io/${{ github.repository }}:${{ env.MAJOR_TAG }}-armv7,
+            ghcr.io/${{ github.repository }}:${{ env.MAJOR_TAG }}-i386
+          push: true
+
+      # Create and push manifest for :latest tag
+      - name: Create and push manifest (:latest)
+        uses: Noelware/docker-manifest-action@master
+        with:
+          base-image: ghcr.io/${{ github.repository }}:${{ env.LATEST_TAG }}
+          extra-images: |
+            ghcr.io/${{ github.repository }}:${{ env.LATEST_TAG }}-amd64,
+            ghcr.io/${{ github.repository }}:${{ env.LATEST_TAG }}-arm64v8,
+            ghcr.io/${{ github.repository }}:${{ env.LATEST_TAG }}-armv7,
+            ghcr.io/${{ github.repository }}:${{ env.LATEST_TAG }}-i386
+          push: true

--- a/.github/workflows/ghcr.yml
+++ b/.github/workflows/ghcr.yml
@@ -1,4 +1,4 @@
-name: build
+name: build for ghcr.io
 
 on:
   workflow_dispatch:

--- a/.github/workflows/ghcr.yml
+++ b/.github/workflows/ghcr.yml
@@ -66,7 +66,8 @@ jobs:
             target/${{ matrix.job.target }}/release/hbbr
             target/${{ matrix.job.target }}/release/hbbs
             target/${{ matrix.job.target }}/release/rustdesk-utils
-        
+          if-no-files-found: error
+  
   # Build and push single-arch Docker images to ghcr.io
   create-s6-overlay-images:
     name: Docker push - ${{ matrix.job.name }}

--- a/.github/workflows/ghcr.yml
+++ b/.github/workflows/ghcr.yml
@@ -39,15 +39,27 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4.2.0
 
-      - name: Install toolchain
-        uses: actions-rs/toolchain@v1
+      #- name: Install toolchain
+        #uses: actions-rs/toolchain@v1
+        #with:
+          #toolchain: "1.70.0"
+          #override: true
+          #default: true
+          #components: rustfmt
+          #profile: minimal
+          #target: ${{ matrix.job.target }}
+    
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@v1
         with:
           toolchain: "1.70.0"
-          override: true
-          default: true
-          components: rustfmt
-          profile: minimal
-          target: ${{ matrix.job.target }}
+          targets: ${{ matrix.job.target }}
+          components: "rustfmt"
+          
+      - uses: Swatinem/rust-cache@v2
+        with:
+          prefix-key: ${{ matrix.job.os }}
 
       - name: Build
         uses: actions-rs/cargo@v1

--- a/.github/workflows/ghcr.yml
+++ b/.github/workflows/ghcr.yml
@@ -38,18 +38,7 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@v4.2.0
-
-      #- name: Install toolchain
-        #uses: actions-rs/toolchain@v1
-        #with:
-          #toolchain: "1.70.0"
-          #override: true
-          #default: true
-          #components: rustfmt
-          #profile: minimal
-          #target: ${{ matrix.job.target }}
     
-
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@v1
         with:
@@ -71,16 +60,28 @@ jobs:
       - name: Exec chmod
         run: chmod -v a+x target/${{ matrix.job.target }}/release/*
 
-      - name: Publish Artifacts
-        uses: actions/upload-artifact@v3
-        with:
-          name: binaries-linux-${{ matrix.job.name }}
-          path: |
-            target/${{ matrix.job.target }}/release/hbbr
-            target/${{ matrix.job.target }}/release/hbbs
-            target/${{ matrix.job.target }}/release/rustdesk-utils
-          if-no-files-found: error
+      #- name: Publish Artifacts
+        #uses: actions/upload-artifact@v3
+        #with:
+          #name: binaries-linux-${{ matrix.job.name }}
+          #path: |
+            #target/${{ matrix.job.target }}/release/hbbr
+            #target/${{ matrix.job.target }}/release/hbbs
+            #target/${{ matrix.job.target }}/release/rustdesk-utils
+          #if-no-files-found: error
 
+
+      - name: Publish Artifacts
+        uses: actions/upload-artifact@v4
+        with:
+            name: binaries-linux-${{ matrix.job.name }}
+            path:
+                - target/${{ matrix.job.target }}/release/hbbr
+                - target/${{ matrix.job.target }}/release/hbbs
+                - target/${{ matrix.job.target }}/release/rustdesk-utils
+            if-no-files-found: error
+        
+        
   # Build and push single-arch Docker images to ghcr.io
   docker:
 

--- a/.github/workflows/ghcr.yml
+++ b/.github/workflows/ghcr.yml
@@ -1,4 +1,4 @@
-name: build for ghcr.io
+name: build
 
 on:
   workflow_dispatch:
@@ -28,10 +28,11 @@ jobs:
       fail-fast: false
       matrix:
         job:
-          - { name: "amd64",   target: "x86_64-unknown-linux-musl", docker_platform: "linux/amd64",  s6_platform: "x86_64" }
-          - { name: "arm64v8", target: "aarch64-unknown-linux-musl", docker_platform: "linux/arm64",  s6_platform: "aarch64" }
-          - { name: "armv7",   target: "armv7-unknown-linux-musleabihf", docker_platform: "linux/arm/v7", s6_platform: "armhf" }
-          - { name: "i386",    target: "i686-unknown-linux-musl", docker_platform: "linux/386",    s6_platform: "i686" }
+          - { name: "amd64",   target: "x86_64-unknown-linux-musl" }
+          - { name: "arm64v8", target: "aarch64-unknown-linux-musl" }
+          - { name: "armv7",   target: "armv7-unknown-linux-musleabihf" }
+          - { name: "i386",    target: "i686-unknown-linux-musl" }
+          - { name: "amd64fb", target: "x86_64-unknown-freebsd" }
 
     steps:
 
@@ -68,12 +69,20 @@ jobs:
             target/${{ matrix.job.target }}/release/rustdesk-utils
           if-no-files-found: error
 
-  # Build and push multi-arch Docker images to ghcr.io with annotations
+  # Build and push single-arch Docker images to ghcr.io
   docker:
 
-    name: Docker Build and Push
+    name: Docker push - ${{ matrix.job.name }}
     needs: build
     runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix:
+        job:
+          - { name: "amd64",   docker_platform: "linux/amd64",  s6_platform: "x86_64" }
+          - { name: "arm64v8", docker_platform: "linux/arm64",  s6_platform: "aarch64" }
+          - { name: "armv7",   docker_platform: "linux/arm/v7", s6_platform: "armhf" }
+          - { name: "i386",    docker_platform: "linux/386",    s6_platform: "i686" }
 
     permissions:
       contents: read
@@ -83,11 +92,11 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@v3
-
+        
       - name: Download binaries
         uses: actions/download-artifact@v3
         with:
-          name: binaries-linux-*
+          name: binaries-linux-${{ matrix.job.name }}
           path: docker/rootfs/usr/bin
 
       - name: Make binaries executable
@@ -95,7 +104,7 @@ jobs:
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
-
+      
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
 
@@ -106,28 +115,114 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-
+        
       - name: Extract metadata (tags, labels) for Docker
         id: meta
         uses: docker/metadata-action@v4
         with:
           images: ghcr.io/${{ github.repository }}-s6
-          tags: |
-            type=ref,event=branch
-            type=raw,value=${{ env.LATEST_TAG }}
-            type=raw,value=${{ github.ref_name }}
-          labels: |
-            org.opencontainers.image.description="RustDesk Server s6-overlay image, running hbbs, hbbr at one container."
 
-      - name: Build and push Docker images
+      - name: Get git tag
+        id: vars
+        run: |
+          T=${GITHUB_REF#refs/*/}
+          M=${T%%.*}
+          echo "GIT_TAG=$T" >> $GITHUB_ENV
+          echo "MAJOR_TAG=$M" >> $GITHUB_ENV
+
+      - name: Build and push Docker image
         uses: docker/build-push-action@v5
         with:
           context: "./docker"
-          platforms: linux/amd64,linux/arm64,linux/arm/v7,linux/386
+          platforms: ${{ matrix.job.docker_platform }}
           push: true
           provenance: false
           build-args: |
             S6_ARCH=${{ matrix.job.s6_platform }}
-          tags: ${{ steps.meta.outputs.tags }}
+          tags: |
+            ghcr.io/${{ github.repository }}-s6:${{ env.LATEST_TAG }}-${{ matrix.job.name }}
+            ghcr.io/${{ github.repository }}-s6:${{ env.GIT_TAG }}-${{ matrix.job.name }}
+            ghcr.io/${{ github.repository }}-s6:${{ env.MAJOR_TAG }}-${{ matrix.job.name }}
           labels: ${{ steps.meta.outputs.labels }}
-          annotations: ${{ steps.meta.outputs.labels }}
+          annotations: |
+            org.opencontainers.image.description=Your Image Description Here
+
+  # Build and push multi-arch Docker images to ghcr.io
+  docker-manifest:
+
+    name: Docker manifest
+    needs: docker
+    runs-on: ubuntu-24.04
+
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+
+      - name: Log in to GitHub Container Registry
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Get git tag
+        id: vars
+        run: |
+          T=${GITHUB_REF#refs/*/}
+          M=${T%%.*}
+          echo "GIT_TAG=$T" >> $GITHUB_ENV
+          echo "MAJOR_TAG=$M" >> $GITHUB_ENV
+
+      # Create and push manifest for :ve.rs.ion tag
+      - name: Create and push manifest (:ve.rs.ion)
+        uses: docker/build-push-action@v5
+        with:
+          push: true
+          provenance: false
+          platforms: linux/amd64,linux/arm64,linux/arm/v7,linux/386
+          images: ghcr.io/${{ github.repository }}-s6:${{ env.GIT_TAG }}
+          tags: ghcr.io/${{ github.repository }}-s6:${{ env.GIT_TAG }}
+          manifests: |
+            ghcr.io/${{ github.repository }}-s6:${{ env.GIT_TAG }}-amd64,
+            ghcr.io/${{ github.repository }}-s6:${{ env.GIT_TAG }}-arm64v8,
+            ghcr.io/${{ github.repository }}-s6:${{ env.GIT_TAG }}-armv7,
+            ghcr.io/${{ github.repository }}-s6:${{ env.GIT_TAG }}-i386
+          annotations: |
+            org.opencontainers.image.description=Your Image Description Here
+
+      # Create and push manifest for :major tag
+      - name: Create and push manifest (:major)
+        uses: docker/build-push-action@v5
+        with:
+          push: true
+          provenance: false
+          platforms: linux/amd64,linux/arm64,linux/arm/v7,linux/386
+          images: ghcr.io/${{ github.repository }}-s6:${{ env.MAJOR_TAG }}
+          tags: ghcr.io/${{ github.repository }}-s6:${{ env.MAJOR_TAG }}
+          manifests: |
+            ghcr.io/${{ github.repository }}-s6:${{ env.MAJOR_TAG }}-amd64,
+            ghcr.io/${{ github.repository }}-s6:${{ env.MAJOR_TAG }}-arm64v8,
+            ghcr.io/${{ github.repository }}-s6:${{ env.MAJOR_TAG }}-armv7,
+            ghcr.io/${{ github.repository }}-s6:${{ env.MAJOR_TAG }}-i386
+          annotations: |
+            org.opencontainers.image.description=Your Image Description Here
+
+      # Create and push manifest for :latest tag
+      - name: Create and push manifest (:latest)
+        uses: docker/build-push-action@v5
+        with:
+          push: true
+          provenance: false
+          platforms: linux/amd64,linux/arm64,linux/arm/v7,linux/386
+          images: ghcr.io/${{ github.repository }}-s6:${{ env.LATEST_TAG }}
+          tags: ghcr.io/${{ github.repository }}-s6:${{ env.LATEST_TAG }}
+          manifests: |
+            ghcr.io/${{ github.repository }}-s6:${{ env.LATEST_TAG }}-amd64,
+            ghcr.io/${{ github.repository }}-s6:${{ env.LATEST_TAG }}-arm64v8,
+            ghcr.io/${{ github.repository }}-s6:${{ env.LATEST_TAG }}-armv7,
+            ghcr.io/${{ github.repository }}-s6:${{ env.LATEST_TAG }}-i386
+          annotations: |
+            org.opencontainers.image.description=Your Image Description Here

--- a/.github/workflows/ghcr.yml
+++ b/.github/workflows/ghcr.yml
@@ -267,7 +267,7 @@ jobs:
           merge-multiple: true
 
       - name: Make binaries executable
-        run: chmod -v a+x docker/rootfs/usr/bin/*
+        run: chmod -v a+x docker-classic/*
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3

--- a/.github/workflows/ghcr.yml
+++ b/.github/workflows/ghcr.yml
@@ -160,6 +160,17 @@ jobs:
 
     steps:
 
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+        with:
+          driver: docker-container
+
       - name: Log in to GitHub Container Registry
         if: github.event_name != 'pull_request'
         uses: docker/login-action@v2
@@ -176,53 +187,47 @@ jobs:
           echo "GIT_TAG=$T" >> $GITHUB_ENV
           echo "MAJOR_TAG=$M" >> $GITHUB_ENV
 
-      # Create and push manifest for :ve.rs.ion tag
       - name: Create and push manifest (:ve.rs.ion)
         uses: docker/build-push-action@v5
         with:
           push: true
           provenance: false
           platforms: linux/amd64,linux/arm64,linux/arm/v7,linux/386
-          images: ghcr.io/${{ github.repository }}-s6:${{ env.GIT_TAG }}
           tags: ghcr.io/${{ github.repository }}-s6:${{ env.GIT_TAG }}
+          labels: |
+            org.opencontainers.image.description=Your Image Description Here
           manifests: |
             ghcr.io/${{ github.repository }}-s6:${{ env.GIT_TAG }}-amd64,
             ghcr.io/${{ github.repository }}-s6:${{ env.GIT_TAG }}-arm64v8,
             ghcr.io/${{ github.repository }}-s6:${{ env.GIT_TAG }}-armv7,
             ghcr.io/${{ github.repository }}-s6:${{ env.GIT_TAG }}-i386
-          annotations: |
-            org.opencontainers.image.description=Your Image Description Here
 
-      # Create and push manifest for :major tag
       - name: Create and push manifest (:major)
         uses: docker/build-push-action@v5
         with:
           push: true
           provenance: false
           platforms: linux/amd64,linux/arm64,linux/arm/v7,linux/386
-          images: ghcr.io/${{ github.repository }}-s6:${{ env.MAJOR_TAG }}
           tags: ghcr.io/${{ github.repository }}-s6:${{ env.MAJOR_TAG }}
+          labels: |
+            org.opencontainers.image.description=Your Image Description Here
           manifests: |
             ghcr.io/${{ github.repository }}-s6:${{ env.MAJOR_TAG }}-amd64,
             ghcr.io/${{ github.repository }}-s6:${{ env.MAJOR_TAG }}-arm64v8,
             ghcr.io/${{ github.repository }}-s6:${{ env.MAJOR_TAG }}-armv7,
             ghcr.io/${{ github.repository }}-s6:${{ env.MAJOR_TAG }}-i386
-          annotations: |
-            org.opencontainers.image.description=Your Image Description Here
 
-      # Create and push manifest for :latest tag
       - name: Create and push manifest (:latest)
         uses: docker/build-push-action@v5
         with:
           push: true
           provenance: false
           platforms: linux/amd64,linux/arm64,linux/arm/v7,linux/386
-          images: ghcr.io/${{ github.repository }}-s6:${{ env.LATEST_TAG }}
           tags: ghcr.io/${{ github.repository }}-s6:${{ env.LATEST_TAG }}
+          labels: |
+            org.opencontainers.image.description=Your Image Description Here
           manifests: |
             ghcr.io/${{ github.repository }}-s6:${{ env.LATEST_TAG }}-amd64,
             ghcr.io/${{ github.repository }}-s6:${{ env.LATEST_TAG }}-arm64v8,
             ghcr.io/${{ github.repository }}-s6:${{ env.LATEST_TAG }}-armv7,
             ghcr.io/${{ github.repository }}-s6:${{ env.LATEST_TAG }}-i386
-          annotations: |
-            org.opencontainers.image.description=Your Image Description Here

--- a/.github/workflows/ghcr.yml
+++ b/.github/workflows/ghcr.yml
@@ -269,7 +269,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           pattern: binaries-linux-${{ matrix.job.name }}
-          path: docker/rootfs/usr/bin
+          path: docker-classic
           merge-multiple: true
 
       - name: Make binaries executable

--- a/.github/workflows/ghcr.yml
+++ b/.github/workflows/ghcr.yml
@@ -37,7 +37,7 @@ jobs:
     steps:
 
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4.2.0
 
       - name: Install toolchain
         uses: actions-rs/toolchain@v1
@@ -91,7 +91,7 @@ jobs:
     steps:
 
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4.2.0
         
       - name: Download binaries
         uses: actions/download-artifact@v3
@@ -103,14 +103,14 @@ jobs:
         run: chmod -v a+x docker/rootfs/usr/bin/*
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v3.2.0
       
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3.6.1
 
       - name: Log in to GitHub Container Registry
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3.3.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -160,7 +160,7 @@ jobs:
 
       - name: Log in to GitHub Container Registry
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3.3.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/ghcr.yml
+++ b/.github/workflows/ghcr.yml
@@ -37,7 +37,7 @@ jobs:
     steps:
 
       - name: Checkout
-        uses: actions/checkout@v4.2.0
+        uses: actions/checkout@v4
     
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@v1
@@ -102,7 +102,7 @@ jobs:
     steps:
 
       - name: Checkout
-        uses: actions/checkout@v4.2.0
+        uses: actions/checkout@v4
         
       #- name: Download binaries
         #uses: actions/download-artifact@v3
@@ -121,14 +121,14 @@ jobs:
         run: chmod -v a+x docker/rootfs/usr/bin/*
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3.2.0
+        uses: docker/setup-qemu-action@v3
       
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3.6.1
+        uses: docker/setup-buildx-action@v3
 
       - name: Log in to GitHub Container Registry
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@v3.3.0
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -178,7 +178,7 @@ jobs:
 
       - name: Log in to GitHub Container Registry
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@v3.3.0
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/ghcr.yml
+++ b/.github/workflows/ghcr.yml
@@ -15,7 +15,7 @@ env:
 
 permissions:
   contents: read
-  packages: write
+  packages: write # So need to set "secrets.GITHUB_TOKEN"
 
 jobs:
 

--- a/.github/workflows/ghcr.yml
+++ b/.github/workflows/ghcr.yml
@@ -1,4 +1,4 @@
-name: build
+name: build ghcr
 
 on:
   workflow_dispatch:

--- a/.github/workflows/ghcr.yml
+++ b/.github/workflows/ghcr.yml
@@ -37,7 +37,7 @@ jobs:
     steps:
 
       - name: Checkout
-        uses: actions/checkout@v4.2.0
+        uses: actions/checkout@v3
 
       - name: Install toolchain
         uses: actions-rs/toolchain@v1
@@ -68,8 +68,7 @@ jobs:
             target/${{ matrix.job.target }}/release/hbbs
             target/${{ matrix.job.target }}/release/rustdesk-utils
           if-no-files-found: error
-  
-  # S6 Version
+
   # Build and push single-arch Docker images to ghcr.io
   docker:
 
@@ -92,10 +91,10 @@ jobs:
     steps:
 
       - name: Checkout
-        uses: actions/checkout@v4.2.0
+        uses: actions/checkout@v3
         
       - name: Download binaries
-        uses: actions/download-artifact@v4.1.8
+        uses: actions/download-artifact@v3
         with:
           name: binaries-linux-${{ matrix.job.name }}
           path: docker/rootfs/usr/bin
@@ -104,14 +103,14 @@ jobs:
         run: chmod -v a+x docker/rootfs/usr/bin/*
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3.2.0
+        uses: docker/setup-qemu-action@v2
       
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3.6.1
+        uses: docker/setup-buildx-action@v2
 
       - name: Log in to GitHub Container Registry
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@v3.3.0
+        uses: docker/login-action@v2
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -119,7 +118,7 @@ jobs:
         
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@v5.5.1
+        uses: docker/metadata-action@v4
         with:
           images: ghcr.io/${{ github.repository }}-s6
 
@@ -132,7 +131,7 @@ jobs:
           echo "MAJOR_TAG=$M" >> $GITHUB_ENV
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v6.8.0
+        uses: docker/build-push-action@v5
         with:
           context: "./docker"
           platforms: ${{ matrix.job.docker_platform }}
@@ -161,7 +160,7 @@ jobs:
 
       - name: Log in to GitHub Container Registry
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@v3.3.0
+        uses: docker/login-action@v2
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -177,7 +176,7 @@ jobs:
 
       # Create and push manifest for :ve.rs.ion tag
       - name: Create and push manifest (:ve.rs.ion)
-        uses: Noelware/docker-manifest-action@v0.4.2
+        uses: Noelware/docker-manifest-action@master
         if: github.event_name != 'workflow_dispatch'
         with:
           base-image: ghcr.io/${{ github.repository }}-s6:${{ env.GIT_TAG }}
@@ -188,140 +187,21 @@ jobs:
             ghcr.io/${{ github.repository }}-s6:${{ env.GIT_TAG }}-i386
           push: true
 
-      # Create and push manifest for :latest tag
-      - name: Create and push manifest (:latest)
-        uses: Noelware/docker-manifest-action@v0.4.2
+      # Create and push manifest for :major tag
+      - name: Create and push manifest (:major)
+        uses: Noelware/docker-manifest-action@master
         with:
-          base-image: ghcr.io/${{ github.repository }}-s6:${{ env.LATEST_TAG }}
+          base-image: ghcr.io/${{ github.repository }}-s6:${{ env.MAJOR_TAG }}
           extra-images: |
-            ghcr.io/${{ github.repository }}-s6:${{ env.LATEST_TAG }}-amd64,
-            ghcr.io/${{ github.repository }}-s6:${{ env.LATEST_TAG }}-arm64v8,
-            ghcr.io/${{ github.repository }}-s6:${{ env.LATEST_TAG }}-armv7,
-            ghcr.io/${{ github.repository }}-s6:${{ env.LATEST_TAG }}-i386
-          push: true
-
-
-
-  # Classic Version
-  # Build and push single-arch Docker images to ghcr.io
-  docker-classic:
-
-    name: Docker push - ${{ matrix.job.name }}
-    needs: build
-    runs-on: ubuntu-24.04
-    strategy:
-      fail-fast: false
-      matrix:
-        job:
-          - { name: "amd64",   docker_platform: "linux/amd64",  s6_platform: "x86_64" }
-          - { name: "arm64v8", docker_platform: "linux/arm64",  s6_platform: "aarch64" }
-          - { name: "armv7",   docker_platform: "linux/arm/v7", s6_platform: "armhf" }
-          - { name: "i386",    docker_platform: "linux/386",    s6_platform: "i686" }
-
-    permissions:
-      contents: read
-      packages: write
-
-    steps:
-
-      - name: Checkout
-        uses: actions/checkout@v4.2.0
-        
-      - name: Download binaries
-        uses: actions/download-artifact@v4.1.8
-        with:
-          name: binaries-linux-${{ matrix.job.name }}
-          path: docker/rootfs/usr/bin
-
-      - name: Make binaries executable
-        run: chmod -v a+x docker/rootfs/usr/bin/*
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3.2.0
-      
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3.6.1
-
-      - name: Log in to GitHub Container Registry
-        if: github.event_name != 'pull_request'
-        uses: docker/login-action@v3.3.0
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-        
-      - name: Extract metadata (tags, labels) for Docker
-        id: meta
-        uses: docker/metadata-action@v5.5.1
-        with:
-          images: ghcr.io/${{ github.repository }}
-
-      - name: Get git tag
-        id: vars
-        run: |
-          T=${GITHUB_REF#refs/*/}
-          M=${T%%.*}
-          echo "GIT_TAG=$T" >> $GITHUB_ENV
-          echo "MAJOR_TAG=$M" >> $GITHUB_ENV
-
-      - name: Build and push Docker image
-        uses: docker/build-push-action@v6.8.0
-        with:
-          context: "./docker-classic"
-          platforms: ${{ matrix.job.docker_platform }}
-          push: true
-          provenance: false
-          tags: |
-            ghcr.io/${{ github.repository }}-s6:${{ env.LATEST_TAG }}-${{ matrix.job.name }}
-            ghcr.io/${{ github.repository }}-s6:${{ env.GIT_TAG }}-${{ matrix.job.name }}
-            ghcr.io/${{ github.repository }}-s6:${{ env.MAJOR_TAG }}-${{ matrix.job.name }}
-          labels: ${{ steps.meta.outputs.labels }}
-
-  # Build and push multi-arch Docker images to ghcr.io
-  docker-classic-manifest:
-
-    name: Docker manifest
-    needs: docker-classic
-    runs-on: ubuntu-24.04
-
-    permissions:
-      contents: read
-      packages: write
-
-    steps:
-
-      - name: Log in to GitHub Container Registry
-        if: github.event_name != 'pull_request'
-        uses: docker/login-action@v3.3.0
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Get git tag
-        id: vars
-        run: |
-          T=${GITHUB_REF#refs/*/}
-          M=${T%%.*}
-          echo "GIT_TAG=$T" >> $GITHUB_ENV
-          echo "MAJOR_TAG=$M" >> $GITHUB_ENV
-
-      # Create and push manifest for :ve.rs.ion tag
-      - name: Create and push manifest (:ve.rs.ion)
-        uses: Noelware/docker-manifest-action@v0.4.2
-        if: github.event_name != 'workflow_dispatch'
-        with:
-          base-image: ghcr.io/${{ github.repository }}-s6:${{ env.GIT_TAG }}
-          extra-images: |
-            ghcr.io/${{ github.repository }}-s6:${{ env.GIT_TAG }}-amd64,
-            ghcr.io/${{ github.repository }}-s6:${{ env.GIT_TAG }}-arm64v8,
-            ghcr.io/${{ github.repository }}-s6:${{ env.GIT_TAG }}-armv7,
-            ghcr.io/${{ github.repository }}-s6:${{ env.GIT_TAG }}-i386
+            ghcr.io/${{ github.repository }}-s6:${{ env.MAJOR_TAG }}-amd64,
+            ghcr.io/${{ github.repository }}-s6:${{ env.MAJOR_TAG }}-arm64v8,
+            ghcr.io/${{ github.repository }}-s6:${{ env.MAJOR_TAG }}-armv7,
+            ghcr.io/${{ github.repository }}-s6:${{ env.MAJOR_TAG }}-i386
           push: true
 
       # Create and push manifest for :latest tag
       - name: Create and push manifest (:latest)
-        uses: Noelware/docker-manifest-action@v0.4.2
+        uses: Noelware/docker-manifest-action@master
         with:
           base-image: ghcr.io/${{ github.repository }}-s6:${{ env.LATEST_TAG }}
           extra-images: |


### PR DESCRIPTION
https://github.com/rustdesk/rustdesk-server/issues/465

* No any `secrets` needed to run this action, you could try after you merged, or [you could check my action.](https://github.com/xlionjuan/rustdesk-server/actions/workflows/ghcr.yml)
* All actions in it are latest
* All runners are use `ubuntu-24.04`, no any problem found

## Test
I've published to [ghcr.io/xlionjuan/rustdesk-server](https://github.com/xlionjuan?tab=packages&repo_name=rustdesk-server) in order to test.

I've test:
* `ghcr.io/xlionjuan/rustdesk-server`
  * `latest` tag
  * `latest-amd64` tag
  * `latest-i386` tag

* `ghcr.io/xlionjuan/rustdesk-server-s6`
  * `latest` tag
  * `latest-amd64` tag
  * `latest-i386` tag

I only have x86 machine, but other architectures should works in theory.