### PR TITLE
README: Restructure Container expression; add ghcr; multiple tidy up

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,6 +330,7 @@ These packages are meant for the following distributions:
 - Ubuntu 22.04 LTS
 - Ubuntu 20.04 LTS
 - Ubuntu 18.04 LTS
+- Debian 12 bookworm
 - Debian 11 bullseye
 - Debian 10 buster
 

--- a/README.md
+++ b/README.md
@@ -34,17 +34,17 @@ Three executables will be generated in target/release.
 
 You can find updated binaries on the [Releases](https://github.com/rustdesk/rustdesk-server/releases) page.
 
-If you want extra features [RustDesk Server Pro](https://rustdesk.com/pricing.html) might suit you better.
+If you want extra features, [RustDesk Server Pro](https://rustdesk.com/pricing.html) might suit you better.
 
 If you want to develop your own server, [rustdesk-server-demo](https://github.com/rustdesk/rustdesk-server-demo) might be a better and simpler start for you than this repo.
 
 ## Docker images
 
-Docker images are automatically generated and published on every GitHub release. We have 2 kind of images.
+Docker images are automatically generated and published to [Docker Hub](https://hub.docker.com/r/rustdesk/rustdesk-server/) and [GitHub Container Registry](https://github.com/rustdesk?tab=packages&repo_name=rustdesk-server) on every GitHub release. We have 2 kind of images.
 
 ### Classic image
 
-These images are built from scratch with two main binaries (`hbbs` and `hbbr`). They're available on [Docker hub](https://hub.docker.com/r/rustdesk/rustdesk-server/) with these architectures:
+These images are built from scratch with two main binaries (`hbbs` and `hbbr`). They're available on [Docker Hub](https://hub.docker.com/r/rustdesk/rustdesk-server/) and [GitHub Container Registry](https://github.com/rustdesk/rustdesk-server/pkgs/container/rustdesk-server) with these architectures:
 
 * amd64
 * arm64v8
@@ -126,16 +126,21 @@ Edit line 16 to point to your relay server (the one listening on port 21117). Yo
 
 ## S6-overlay based images
 
-These images are build against `busybox:stable` with the addition of the binaries (both `hbbs` and `hbbr`) and [S6-overlay](https://github.com/just-containers/s6-overlay). They're available on [Docker hub](https://hub.docker.com/r/rustdesk/rustdesk-server-s6/) with these tags:
+These images are build against `busybox:stable` with the addition of the binaries (both `hbbs` and `hbbr`) and [S6-overlay](https://github.com/just-containers/s6-overlay). They're available on [Docker hub](https://hub.docker.com/r/rustdesk/rustdesk-server-s6/) and [GitHub Container Registry](https://github.com/rustdesk/rustdesk-server/pkgs/container/rustdesk-server) with these architectures:
 
-| Version       | image:tag                         |
-| ------------- | --------------------------------- |
-| latest        | `rustdesk/rustdesk-server:latest` |
-| Major version | `rustdesk/rustdesk-server:1`      |
+* amd64
+* i386
+* arm64v8
+* armv7
 
-You're strongly encouraged to use the `multiarch` image either with the `major version` or `latest` tag.
+You could use `latest` tag or major version tag `1` with supported architectures:
 
-The S6-overlay acts as a supervisor and keeps both process running, so with this image there's no need to have two separate running containers.
+| Version       | image:tag                            |
+| ------------- | ------------------------------------ |
+| latest        | `rustdesk/rustdesk-server-s6:latest` |
+| Major version | `rustdesk/rustdesk-server-s6:1`      |
+
+The S6-overlay acts as a supervisor and keeps both process running, so with this image, there's no need to have two separate running containers.
 
 You can start these images directly with `docker run` with this command:
 
@@ -242,7 +247,7 @@ services:
 #### Use Docker secrets to store the key pair
 
 You can alternatively use docker secrets to store the keys.
-This is useful if you're using **docker-compose** or **docker swarm**.
+This is useful if you're using **docker-compose** or **Docker Swarm**.
 Just follow this examples:
 
 ```bash
@@ -315,9 +320,10 @@ Secret Key:  egAVd44u33ZEUIDTtksGcHeVeAwywarEdHmf99KM5ajwEsuG3NQFT9coAfiZ6nen4hf
 
 ## .deb packages
 
-Separate .deb packages are available for each binary, you can find them in the [releases](https://github.com/rustdesk/rustdesk-server/releases).
+Separate .deb packages are available for each binary, you can find them in the [Releases](https://github.com/rustdesk/rustdesk-server/releases).
 These packages are meant for the following distributions:
 
+- Ubuntu 24.04 LTS
 - Ubuntu 22.04 LTS
 - Ubuntu 20.04 LTS
 - Ubuntu 18.04 LTS
@@ -326,7 +332,7 @@ These packages are meant for the following distributions:
 
 ## ENV variables
 
-hbbs and hbbr can be configured using these ENV variables.
+`hbbs` and `hbbr` can be configured using these ENV variables.
 You can specify the variables as usual or use an `.env` file.
 
 | variable | binary | description |

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Three executables will be generated in target/release.
 - hbbr - RustDesk relay server
 - rustdesk-utils - RustDesk CLI utilities
 
-You can find updated binaries on the [releases](https://github.com/rustdesk/rustdesk-server/releases) page.
+You can find updated binaries on the [Releases](https://github.com/rustdesk/rustdesk-server/releases) page.
 
 If you want extra features [RustDesk Server Pro](https://rustdesk.com/pricing.html) might suit you better.
 
@@ -40,16 +40,23 @@ If you want to develop your own server, [rustdesk-server-demo](https://github.co
 
 ## Docker images
 
-Docker images are automatically generated and published on every github release. We have 2 kind of images.
+Docker images are automatically generated and published on every GitHub release. We have 2 kind of images.
 
 ### Classic image
 
-These images are build against `ubuntu-20.04` with the only addition of the main binaries (`hbbr` and `hbbs`). They're available on [Docker hub](https://hub.docker.com/r/rustdesk/rustdesk-server/) with these tags:
+These images are built from scratch with two main binaries (`hbbr` and `hbbs`). They're available on [Docker hub](https://hub.docker.com/r/rustdesk/rustdesk-server/) with these architectures:
 
-| architecture | image:tag |
-| --- | --- |
-| amd64 | `rustdesk/rustdesk-server:latest` |
-| arm64v8 | `rustdesk/rustdesk-server:latest-arm64v8` |
+* amd64
+* arm64v8
+* armv7
+
+You could use `latest` tag or major version tag `1` with supported architectures:
+
+| Version       | image:tag                         |
+| ------------- | --------------------------------- |
+| latest        | `rustdesk/rustdesk-server:latest` |
+| Major version | `rustdesk/rustdesk-server:1`      |
+
 
 You can start these images directly with `docker run` with these commands:
 
@@ -121,23 +128,10 @@ Edit line 16 to point to your relay server (the one listening on port 21117). Yo
 
 These images are build against `busybox:stable` with the addition of the binaries (both hbbr and hbbs) and [S6-overlay](https://github.com/just-containers/s6-overlay). They're available on [Docker hub](https://hub.docker.com/r/rustdesk/rustdesk-server-s6/) with these tags:
 
-| architecture | version | image:tag |
-| --- | --- | --- |
-| multiarch | latest | `rustdesk/rustdesk-server-s6:latest` |
-| amd64 | latest | `rustdesk/rustdesk-server-s6:latest-amd64` |
-| i386 | latest | `rustdesk/rustdesk-server-s6:latest-i386` |
-| arm64v8 | latest | `rustdesk/rustdesk-server-s6:latest-arm64v8` |
-| armv7 | latest | `rustdesk/rustdesk-server-s6:latest-armv7` |
-| multiarch | 2 | `rustdesk/rustdesk-server-s6:2` |
-| amd64 | 2 | `rustdesk/rustdesk-server-s6:2-amd64` |
-| i386 | 2 | `rustdesk/rustdesk-server-s6:2-i386` |
-| arm64v8 | 2 | `rustdesk/rustdesk-server-s6:2-arm64v8` |
-| armv7 | 2 | `rustdesk/rustdesk-server-s6:2-armv7` |
-| multiarch | 2.0.0 | `rustdesk/rustdesk-server-s6:2.0.0` |
-| amd64 | 2.0.0 | `rustdesk/rustdesk-server-s6:2.0.0-amd64` |
-| i386 | 2.0.0 | `rustdesk/rustdesk-server-s6:2.0.0-i386` |
-| arm64v8 | 2.0.0 | `rustdesk/rustdesk-server-s6:2.0.0-arm64v8` |
-| armv7 | 2.0.0 | `rustdesk/rustdesk-server-s6:2.0.0-armv7` |
+| Version       | image:tag                         |
+| ------------- | --------------------------------- |
+| latest        | `rustdesk/rustdesk-server:latest` |
+| Major version | `rustdesk/rustdesk-server:1`      |
 
 You're strongly encouraged to use the `multiarch` image either with the `major version` or `latest` tag.
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Docker images are automatically generated and published on every GitHub release.
 
 ### Classic image
 
-These images are built from scratch with two main binaries (`hbbr` and `hbbs`). They're available on [Docker hub](https://hub.docker.com/r/rustdesk/rustdesk-server/) with these architectures:
+These images are built from scratch with two main binaries (`hbbs` and `hbbr`). They're available on [Docker hub](https://hub.docker.com/r/rustdesk/rustdesk-server/) with these architectures:
 
 * amd64
 * arm64v8
@@ -126,7 +126,7 @@ Edit line 16 to point to your relay server (the one listening on port 21117). Yo
 
 ## S6-overlay based images
 
-These images are build against `busybox:stable` with the addition of the binaries (both hbbr and hbbs) and [S6-overlay](https://github.com/just-containers/s6-overlay). They're available on [Docker hub](https://hub.docker.com/r/rustdesk/rustdesk-server-s6/) with these tags:
+These images are build against `busybox:stable` with the addition of the binaries (both `hbbs` and `hbbr`) and [S6-overlay](https://github.com/just-containers/s6-overlay). They're available on [Docker hub](https://hub.docker.com/r/rustdesk/rustdesk-server-s6/) with these tags:
 
 | Version       | image:tag                         |
 | ------------- | --------------------------------- |

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ If you want to develop your own server, [rustdesk-server-demo](https://github.co
 
 ## Docker images
 
-Docker images are automatically generated and published to [Docker Hub](https://hub.docker.com/r/rustdesk/rustdesk-server/) and [GitHub Container Registry](https://github.com/rustdesk?tab=packages&repo_name=rustdesk-server) on every GitHub release. We have 2 kind of images.
+Docker images are automatically generated and published to [Docker Hub](https://hub.docker.com/r/rustdesk) and [GitHub Container Registry](https://github.com/rustdesk?tab=packages&repo_name=rustdesk-server) on every GitHub release. We have 2 kind of images.
 
 ### Classic image
 

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ Edit line 16 to point to your relay server (the one listening on port 21117). Yo
 (docker-compose credit goes to @lukebarone and @QuiGonLeong)
 
 > [!NOTE]  
-> The rustdesk/rustdesk-server:latest in China may be replaced with the latest version number on Docker Hub, such as rustdesk-server:1.1.10-3. Otherwise, the old version may be pulled due to image acceleration.
+> The rustdesk/rustdesk-server:latest in China may be replaced with the latest version number on Docker Hub, such as `rustdesk-server:1.1.10-3`. Otherwise, the old version may be pulled due to image acceleration.
 
 > [!NOTE]  
 > If you are experiencing issues pulling from Docker Hub, try pulling from the [GitHub Container Registry](https://github.com/rustdesk/rustdesk-server/pkgs/container/rustdesk-server) instead.

--- a/README.md
+++ b/README.md
@@ -121,8 +121,11 @@ Edit line 16 to point to your relay server (the one listening on port 21117). Yo
 
 (docker-compose credit goes to @lukebarone and @QuiGonLeong)
 
+> [!NOTE]  
+> The rustdesk/rustdesk-server:latest in China may be replaced with the latest version number on Docker Hub, such as rustdesk-server:1.1.10-3. Otherwise, the old version may be pulled due to image acceleration.
 
-> Note that here, the rustdesk/rustdesk-server:latest in China may be replaced with the latest version number on dockerhub, such as rustdesk-server:1.1.10-3. Otherwise, the old version may be pulled due to image acceleration.
+> [!NOTE]  
+> If you are experiencing issues pulling from Docker Hub, try pulling from the [GitHub Container Registry](https://github.com/rustdesk/rustdesk-server/pkgs/container/rustdesk-server) instead.
 
 ## S6-overlay based images
 


### PR DESCRIPTION
#478 

* L35: releases to Releases to match GitHub UI
* L37: Add comma
* L43: Add ghcr
* L47:
  * Classic isn't Ubuntu based anymore
  * Add ghcr
  * Del arch specific tag, *we should guide user use merged tags*
  * Restructure expression
* L122:
  * `hbbs` first than `hbbr` everywhere
  * Add ghcr
  * Del arch specific tag, *we should guide user use merged tags*
  * Restructure expression
* L118:
  * GitHub style NOTE
  * Add `
  * Suggest user use ghcr if they can't access Docker Hub
* L251:  Capital the term: Docker Swarm
* L324: releases to Releases to match GitHub UI
* L329,333: Add Ubuntu 24 and Debian 12
* L335: Add `