### PR TITLE
In cargo it is named "rustdesk-utils"

### DIFF
--- a/src/utils.rs
+++ b/src/utils.rs
@@ -10,7 +10,7 @@ use std::{
 fn print_help() {
     println!(
         "Usage:
-    rustdesk-util [command]\n
+    rustdesk-utils [command]\n
 Available Commands:
     genkeypair                                   Generate a new keypair
     validatekeypair [public key] [secret key]    Validate an existing keypair


### PR DESCRIPTION
in command help is used wrong name