### PR TITLE
debian/changelog more like the first two

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,35 +1,59 @@
 rustdesk-server (1.1.14) UNRELEASED; urgency=medium
+
   * Fix windows crash
 
+ -- rustdesk <info@rustdesk.com>  Sat, 25 Jan 2025 20:47:19 +0800
+
 rustdesk-server (1.1.13) UNRELEASED; urgency=medium
+
   * Version check and refactor hbb_common to share with rustdesk client
 
+ -- rustdesk <info@rustdesk.com>  Tue, 21 Jan 2025 01:33:42 +0800
+
 rustdesk-server (1.1.12) UNRELEASED; urgency=medium
+
   * WS real ip
   * Bump s6-overlay to v3.2.0.0 and fix env warnings
 
+ -- rustdesk <info@rustdesk.com>  Mon Oct 7 16:21:36 2024 +0800
+
 rustdesk-server (1.1.11-1) UNRELEASED; urgency=medium
+
   * set reuse port to make restart friendly
   * revert hbbr `-k` to not ruin back-compatibility
 
+ -- rustdesk <info@rustdesk.com>  Fri, 24 May 2024 18:37:11 +0800
+
 rustdesk-server (1.1.11) UNRELEASED; urgency=medium
+
   * change -k to default '-', so you need not to set -k any more
 
+ -- rustdesk <info@rustdesk.com>  Fri, 24 May 2024 18:09:12 +0800
+
 rustdesk-server (1.1.10-3) UNRELEASED; urgency=medium
+
   * fix on -2
+
+ -- rustdesk <info@rustdesk.com>  Wed, 31 Jan 2024 11:30:42 +0800
 
 rustdesk-server (1.1.10-2) UNRELEASED; urgency=medium
 
   * fix hangup signal exit when run with nohup
   * some minors
 
+ -- rustdesk <info@rustdesk.com>  Tue, 30 Jan 2024 19:23:36 +0800
+
 rustdesk-server (1.1.9) UNRELEASED; urgency=medium
 
   * remove unsafe
 
+ -- rustdesk <info@rustdesk.com>  Tue, 5 Dec 2023 17:22:40 +0800
+
 rustdesk-server (1.1.8) UNRELEASED; urgency=medium
 
   * fix test_hbbs and mask in lan
+
+ -- rustdesk <info@rustdesk.com>  Thu, 6 Jul 2023 00:50:11 +0800
 
 rustdesk-server (1.1.7) UNRELEASED; urgency=medium
 


### PR DESCRIPTION
Added "Who and When" lines, added empty lines as separator. The time stamps where retrieved from the git commit log.

All entries look now like:

rustdesk-server (1.1.7) UNRELEASED; urgency=medium

  * ipv6 support

 -- rustdesk <info@rustdesk.com>  Wed, 11 Jan 2023 11:27:00 +0800

rustdesk-server (1.1.6) UNRELEASED; urgency=medium

  * Initial release

 -- open-trade <info@rustdesk.com>  Fri, 15 Jul 2022 12:27:27 +0200