### PR TITLE
Define the `HOME` environmental variable inside the Dockerfile (classic) to allow running rootless

### DIFF
--- a/docker-classic/Dockerfile
+++ b/docker-classic/Dockerfile
@@ -1,4 +1,5 @@
-FROM scratch    
-COPY hbbs /usr/bin/hbbs    
-COPY hbbr /usr/bin/hbbr    
-WORKDIR /root 
+FROM scratch
+COPY hbbs /usr/bin/hbbs
+COPY hbbr /usr/bin/hbbr
+WORKDIR /root
+ENV HOME=/root


### PR DESCRIPTION
When running as a not-root user, the rendezvous server (hbbr) fails to create the config directory (#526): `ERROR [libs/hbb_common/src/config.rs:538] Failed to store  config: Failed to create directory`.

The reason being that when using a non-root user, e.g. `user: 1234`, since it's missing in the `/etc/passwd` the home directory defaults to the root of the filesystem (`/`), but as the container is not running as root, it does not have permission to write there. `/root` is the mapped volume which the user is expected to have already set the correct permissions for the container to run, thus the simples workaround is setting the `HOME` variable to `/root`, where the `.config` directory can be created.