### PR TITLE
feat: enable full peer registration and reachability over WebSocket

### DIFF
--- a/src/rendezvous_server.rs
+++ b/src/rendezvous_server.rs
@@ -660,9 +660,13 @@ impl RendezvousServer {
                         if changed {
                             self.pm.update_pk(id.clone(), peer, addr, rk.uuid, rk.pk, ip).await;
                         }
-                        // Refresh last_reg_time so this peer appears online for status checks
+                        // Always update socket_addr and last_reg_time in memory —
+                        // update_pk only runs when changed=true, but socket_addr must
+                        // always reflect the current WebSocket connection address
                         if let Some(p) = self.pm.get_in_memory(&id).await {
-                            p.write().await.last_reg_time = Instant::now();
+                            let mut p = p.write().await;
+                            p.socket_addr = addr;
+                            p.last_reg_time = Instant::now();
                         }
                         let mut msg_out = RendezvousMessage::new();
                         msg_out.set_register_pk_response(RegisterPkResponse {
@@ -677,6 +681,55 @@ impl RendezvousServer {
                         }
                         return true;
                     }
+                }
+                Some(rendezvous_message::Union::RegisterPeer(rp)) if ws => {
+                    // WebSocket peer heartbeat — update socket_addr and last_reg_time,
+                    // and re-store sink in tcp_punch if this handler still has it
+                    if !rp.id.is_empty() {
+                        let peer = self.pm.get_or(&rp.id).await;
+                        let mut p = peer.write().await;
+                        p.socket_addr = addr;
+                        p.last_reg_time = Instant::now();
+                    }
+                    if let Some(s) = sink.take() {
+                        self.tcp_punch.lock().await.insert(try_into_v4(addr), s);
+                    }
+                    return true;
+                }
+                Some(rendezvous_message::Union::OnlineRequest(or)) if ws => {
+                    // WebSocket peer checking which peers are online — build bitmask and respond
+                    let peers = or.peers;
+                    let mut states = BytesMut::zeroed((peers.len() + 7) / 8);
+                    for (i, peer_id) in peers.iter().enumerate() {
+                        if let Some(peer) = self.pm.get_in_memory(peer_id).await {
+                            let elapsed = peer.read().await.last_reg_time.elapsed().as_millis() as i32;
+                            let states_idx = i / 8;
+                            let bit_idx = 7 - i % 8;
+                            if elapsed < REG_TIMEOUT {
+                                states[states_idx] |= 0x01 << bit_idx;
+                            }
+                        }
+                    }
+                    let mut msg_out = RendezvousMessage::new();
+                    msg_out.set_online_response(OnlineResponse {
+                        states: states.into(),
+                        ..Default::default()
+                    });
+                    // Local sink was taken during RegisterPk — send via tcp_punch
+                    let addr_v4 = try_into_v4(addr);
+                    let tcp_punch = self.tcp_punch.clone();
+                    let mut stored = tcp_punch.lock().await.remove(&addr_v4);
+                    if stored.is_some() {
+                        tokio::spawn(async move {
+                            Self::send_to_sink(&mut stored, msg_out).await;
+                            if let Some(s) = stored {
+                                tcp_punch.lock().await.insert(addr_v4, s);
+                            }
+                        });
+                    } else {
+                        Self::send_to_sink(sink, msg_out).await;
+                    }
+                    return true;
                 }
                 _ => {}
             }
@@ -947,10 +1000,11 @@ impl RendezvousServer {
                     tcp_punch.lock().await.insert(addr_v4, s);
                 }
             });
-        } else {
-            // Target not on a TCP/WS connection — fall back to UDP
+        } else if addr.port() != 0 {
+            // Target not on a TCP/WS connection and has a real UDP port — fall back to UDP
             self.tx.send(Data::Msg(msg.into(), addr)).ok();
         }
+        // If port == 0 and no sink, the WebSocket peer is temporarily disconnected; drop silently
     }
 
     #[inline]
@@ -979,7 +1033,7 @@ impl RendezvousServer {
         let mut sink = self.tcp_punch.lock().await.remove(&addr_v4);
         if sink.is_some() {
             Self::send_to_sink(&mut sink, msg).await;
-        } else {
+        } else if addr.port() != 0 {
             self.tx.send(Data::Msg(msg.into(), addr)).ok();
         }
         Ok(())
@@ -994,8 +1048,13 @@ impl RendezvousServer {
         ws: bool,
     ) -> ResultType<()> {
         let (msg, to_addr) = self.handle_punch_hole_request(addr, ph, key, ws).await?;
-        if let Some(addr) = to_addr {
-            self.tx.send(Data::Msg(msg.into(), addr))?;
+        if let Some(to_addr) = to_addr {
+            if to_addr.port() == 0 {
+                // Target is a WebSocket peer — deliver via stored WS sink
+                self.send_to_tcp(msg, to_addr).await;
+            } else {
+                self.tx.send(Data::Msg(msg.into(), to_addr))?;
+            }
         } else {
             self.send_to_tcp_sync(msg, addr).await?;
         }

--- a/src/rendezvous_server.rs
+++ b/src/rendezvous_server.rs
@@ -989,17 +989,16 @@ impl RendezvousServer {
 
     #[inline]
     async fn send_to_tcp(&mut self, msg: RendezvousMessage, addr: SocketAddr) {
-        let tcp_punch = self.tcp_punch.clone();
         let addr_v4 = try_into_v4(addr);
-        let mut tcp = tcp_punch.lock().await.remove(&addr_v4);
+        let mut tcp = self.tcp_punch.lock().await.remove(&addr_v4);
         if tcp.is_some() {
-            tokio::spawn(async move {
-                Self::send_to_sink(&mut tcp, msg).await;
-                // Re-insert sink so this WebSocket peer can receive future messages
-                if let Some(s) = tcp {
-                    tcp_punch.lock().await.insert(addr_v4, s);
-                }
-            });
+            Self::send_to_sink(&mut tcp, msg).await;
+            // Re-insert sink so this WebSocket peer can receive future messages.
+            // Done inline (no spawn) so there is no window where a concurrent send
+            // sees the map entry missing and incorrectly falls back to UDP.
+            if let Some(s) = tcp {
+                self.tcp_punch.lock().await.insert(addr_v4, s);
+            }
         } else if addr.port() != 0 {
             // Target not on a TCP/WS connection and has a real UDP port — fall back to UDP
             self.tx.send(Data::Msg(msg.into(), addr)).ok();
@@ -1033,6 +1032,9 @@ impl RendezvousServer {
         let mut sink = self.tcp_punch.lock().await.remove(&addr_v4);
         if sink.is_some() {
             Self::send_to_sink(&mut sink, msg).await;
+            if let Some(s) = sink {
+                self.tcp_punch.lock().await.insert(addr_v4, s);
+            }
         } else if addr.port() != 0 {
             self.tx.send(Data::Msg(msg.into(), addr)).ok();
         }

--- a/src/rendezvous_server.rs
+++ b/src/rendezvous_server.rs
@@ -717,15 +717,12 @@ impl RendezvousServer {
                     });
                     // Local sink was taken during RegisterPk — send via tcp_punch
                     let addr_v4 = try_into_v4(addr);
-                    let tcp_punch = self.tcp_punch.clone();
-                    let mut stored = tcp_punch.lock().await.remove(&addr_v4);
+                    let mut stored = self.tcp_punch.lock().await.remove(&addr_v4);
                     if stored.is_some() {
-                        tokio::spawn(async move {
-                            Self::send_to_sink(&mut stored, msg_out).await;
-                            if let Some(s) = stored {
-                                tcp_punch.lock().await.insert(addr_v4, s);
-                            }
-                        });
+                        Self::send_to_sink(&mut stored, msg_out).await;
+                        if let Some(s) = stored {
+                            self.tcp_punch.lock().await.insert(addr_v4, s);
+                        }
                     } else {
                         Self::send_to_sink(sink, msg_out).await;
                     }
@@ -993,9 +990,10 @@ impl RendezvousServer {
         let mut tcp = self.tcp_punch.lock().await.remove(&addr_v4);
         if tcp.is_some() {
             Self::send_to_sink(&mut tcp, msg).await;
-            // Re-insert sink so this WebSocket peer can receive future messages.
-            // Done inline (no spawn) so there is no window where a concurrent send
-            // sees the map entry missing and incorrectly falls back to UDP.
+            // Re-insert sink after send. There is a brief window between remove and
+            // re-insert (while send_to_sink awaits) where a concurrent send sees no
+            // entry; this is an accepted tradeoff since Sink is not Clone and holding
+            // the map lock across the await would block all other peers.
             if let Some(s) = tcp {
                 self.tcp_punch.lock().await.insert(addr_v4, s);
             }

--- a/src/rendezvous_server.rs
+++ b/src/rendezvous_server.rs
@@ -658,7 +658,11 @@ impl RendezvousServer {
                             }
                         }
                         if changed {
-                            self.pm.update_pk(id, peer, addr, rk.uuid, rk.pk, ip).await;
+                            self.pm.update_pk(id.clone(), peer, addr, rk.uuid, rk.pk, ip).await;
+                        }
+                        // Refresh last_reg_time so this peer appears online for status checks
+                        if let Some(p) = self.pm.get_in_memory(&id).await {
+                            p.write().await.last_reg_time = Instant::now();
                         }
                         let mut msg_out = RendezvousMessage::new();
                         msg_out.set_register_pk_response(RegisterPkResponse {

--- a/src/rendezvous_server.rs
+++ b/src/rendezvous_server.rs
@@ -508,7 +508,11 @@ impl RendezvousServer {
                         rf.socket_addr = AddrMangle::encode(addr).into();
                         msg_out.set_request_relay(rf);
                         let peer_addr = peer.read().await.socket_addr;
-                        self.tx.send(Data::Msg(msg_out.into(), peer_addr)).ok();
+                        if peer_addr.port() == 0 {
+                            self.send_to_tcp(msg_out, peer_addr).await;
+                        } else {
+                            self.tx.send(Data::Msg(msg_out.into(), peer_addr)).ok();
+                        }
                     }
                     return true;
                 }
@@ -553,14 +557,122 @@ impl RendezvousServer {
                     msg_out.set_test_nat_response(res);
                     Self::send_to_sink(sink, msg_out).await;
                 }
-                Some(rendezvous_message::Union::RegisterPk(_)) => {
-                    let res = register_pk_response::Result::NOT_SUPPORT;
-                    let mut msg_out = RendezvousMessage::new();
-                    msg_out.set_register_pk_response(RegisterPkResponse {
-                        result: res.into(),
-                        ..Default::default()
-                    });
-                    Self::send_to_sink(sink, msg_out).await;
+                Some(rendezvous_message::Union::RegisterPk(rk)) => {
+                    if !ws {
+                        let mut msg_out = RendezvousMessage::new();
+                        msg_out.set_register_pk_response(RegisterPkResponse {
+                            result: register_pk_response::Result::NOT_SUPPORT.into(),
+                            ..Default::default()
+                        });
+                        Self::send_to_sink(sink, msg_out).await;
+                    } else {
+                        // WebSocket clients (e.g. Mac via Cloudflare) need full registration
+                        if rk.uuid.is_empty() || rk.pk.is_empty() {
+                            return false;
+                        }
+                        let id = rk.id.clone();
+                        let ip = addr.ip().to_string();
+                        if id.len() < 6 {
+                            let mut msg_out = RendezvousMessage::new();
+                            msg_out.set_register_pk_response(RegisterPkResponse {
+                                result: UUID_MISMATCH.into(),
+                                ..Default::default()
+                            });
+                            Self::send_to_sink(sink, msg_out).await;
+                            return false;
+                        } else if !self.check_ip_blocker(&ip, &id).await {
+                            let mut msg_out = RendezvousMessage::new();
+                            msg_out.set_register_pk_response(RegisterPkResponse {
+                                result: TOO_FREQUENT.into(),
+                                ..Default::default()
+                            });
+                            Self::send_to_sink(sink, msg_out).await;
+                            return false;
+                        }
+                        let peer = self.pm.get_or(&id).await;
+                        let (changed, ip_changed) = {
+                            let peer = peer.read().await;
+                            if peer.uuid.is_empty() {
+                                (true, false)
+                            } else {
+                                if peer.uuid == rk.uuid {
+                                    if peer.info.ip != ip && peer.pk != rk.pk {
+                                        drop(peer);
+                                        let mut msg_out = RendezvousMessage::new();
+                                        msg_out.set_register_pk_response(RegisterPkResponse {
+                                            result: UUID_MISMATCH.into(),
+                                            ..Default::default()
+                                        });
+                                        Self::send_to_sink(sink, msg_out).await;
+                                        return false;
+                                    }
+                                } else {
+                                    drop(peer);
+                                    let mut msg_out = RendezvousMessage::new();
+                                    msg_out.set_register_pk_response(RegisterPkResponse {
+                                        result: UUID_MISMATCH.into(),
+                                        ..Default::default()
+                                    });
+                                    Self::send_to_sink(sink, msg_out).await;
+                                    return false;
+                                }
+                                let ip_changed = peer.info.ip != ip;
+                                (
+                                    peer.uuid != rk.uuid || peer.pk != rk.pk || ip_changed,
+                                    ip_changed,
+                                )
+                            }
+                        };
+                        let mut req_pk = peer.read().await.reg_pk;
+                        if req_pk.1.elapsed().as_secs() > 6 {
+                            req_pk.0 = 0;
+                        } else if req_pk.0 > 2 {
+                            let mut msg_out = RendezvousMessage::new();
+                            msg_out.set_register_pk_response(RegisterPkResponse {
+                                result: TOO_FREQUENT.into(),
+                                ..Default::default()
+                            });
+                            Self::send_to_sink(sink, msg_out).await;
+                            return false;
+                        }
+                        req_pk.0 += 1;
+                        req_pk.1 = Instant::now();
+                        peer.write().await.reg_pk = req_pk;
+                        if ip_changed {
+                            let mut lock = IP_CHANGES.lock().await;
+                            if let Some((tm, ips)) = lock.get_mut(&id) {
+                                if tm.elapsed().as_secs() > IP_CHANGE_DUR {
+                                    *tm = Instant::now();
+                                    ips.clear();
+                                    ips.insert(ip.clone(), 1);
+                                } else if let Some(v) = ips.get_mut(&ip) {
+                                    *v += 1;
+                                } else {
+                                    ips.insert(ip.clone(), 1);
+                                }
+                            } else {
+                                lock.insert(
+                                    id.clone(),
+                                    (Instant::now(), HashMap::from([(ip.clone(), 1)])),
+                                );
+                            }
+                        }
+                        if changed {
+                            self.pm.update_pk(id, peer, addr, rk.uuid, rk.pk, ip).await;
+                        }
+                        let mut msg_out = RendezvousMessage::new();
+                        msg_out.set_register_pk_response(RegisterPkResponse {
+                            result: register_pk_response::Result::OK.into(),
+                            ..Default::default()
+                        });
+                        Self::send_to_sink(sink, msg_out).await;
+                        // Keep connection alive and store sink so hbbs can deliver
+                        // incoming connection requests to this WebSocket peer
+                        if let Some(s) = sink.take() {
+                            self.tcp_punch.lock().await.insert(try_into_v4(addr), s);
+                        }
+                        return true;
+                    }
                 }
                 _ => {}
             }
@@ -820,10 +932,21 @@ impl RendezvousServer {
 
     #[inline]
     async fn send_to_tcp(&mut self, msg: RendezvousMessage, addr: SocketAddr) {
-        let mut tcp = self.tcp_punch.lock().await.remove(&try_into_v4(addr));
-        tokio::spawn(async move {
-            Self::send_to_sink(&mut tcp, msg).await;
-        });
+        let tcp_punch = self.tcp_punch.clone();
+        let addr_v4 = try_into_v4(addr);
+        let mut tcp = tcp_punch.lock().await.remove(&addr_v4);
+        if tcp.is_some() {
+            tokio::spawn(async move {
+                Self::send_to_sink(&mut tcp, msg).await;
+                // Re-insert sink so this WebSocket peer can receive future messages
+                if let Some(s) = tcp {
+                    tcp_punch.lock().await.insert(addr_v4, s);
+                }
+            });
+        } else {
+            // Target not on a TCP/WS connection — fall back to UDP
+            self.tx.send(Data::Msg(msg.into(), addr)).ok();
+        }
     }
 
     #[inline]
@@ -848,8 +971,13 @@ impl RendezvousServer {
         msg: RendezvousMessage,
         addr: SocketAddr,
     ) -> ResultType<()> {
-        let mut sink = self.tcp_punch.lock().await.remove(&try_into_v4(addr));
-        Self::send_to_sink(&mut sink, msg).await;
+        let addr_v4 = try_into_v4(addr);
+        let mut sink = self.tcp_punch.lock().await.remove(&addr_v4);
+        if sink.is_some() {
+            Self::send_to_sink(&mut sink, msg).await;
+        } else {
+            self.tx.send(Data::Msg(msg.into(), addr)).ok();
+        }
         Ok(())
     }
 
@@ -878,13 +1006,19 @@ impl RendezvousServer {
         key: &str,
     ) -> ResultType<()> {
         let (msg, to_addr) = self.handle_punch_hole_request(addr, ph, key, false).await?;
-        self.tx.send(Data::Msg(
-            msg.into(),
-            match to_addr {
-                Some(addr) => addr,
-                None => addr,
-            },
-        ))?;
+        match to_addr {
+            Some(to_addr) if to_addr.port() == 0 => {
+                // Target is WebSocket-registered (port 0) — deliver via stored WS sink
+                self.send_to_tcp(msg, to_addr).await;
+            }
+            Some(to_addr) => {
+                self.tx.send(Data::Msg(msg.into(), to_addr))?;
+            }
+            None => {
+                // Error response goes back to the UDP requester
+                self.tx.send(Data::Msg(msg.into(), addr))?;
+            }
+        }
         Ok(())
     }
 


### PR DESCRIPTION
### Problem

Clients that can only reach hbbs via WebSocket (e.g. through a Cloudflare tunnel or any HTTP reverse proxy) could not register as hosts. They showed \"Connecting to RustDesk server\" permanently and could not receive incoming connections. Only the direction *from* the WebSocket peer *to* a UDP-registered peer worked.

### Root cause

Four places in `rendezvous_server.rs` assumed every registered peer is reachable via UDP:

1. `handle_tcp` returned `NOT_SUPPORT` for `RegisterPk` on all TCP/WebSocket connections.
2. `handle_udp_punch_hole_request` always enqueued the punch-hole message on the UDP channel, even when the target peer has no real UDP port.
3. The `RequestRelay` arm in `handle_tcp` did the same.
4. `send_to_tcp` / `send_to_tcp_sync` silently dropped messages when the target had no stored TCP sink, with no fallback for UDP peers.

### How WebSocket peers are detected

`handle_listener_inner` already extracts the real client IP from `X-Real-IP` / `X-Forwarded-For` when accepting a WebSocket upgrade, but there is no real UDP port, so `addr` becomes `<real-ip>:0`. UDP peers always have a non-zero port. **Port == 0 is therefore an unambiguous sentinel for a WebSocket-registered peer.**

### Changes

| # | Where | What |
|---|-------|------|
| 1 | `handle_tcp` (`RegisterPk`, `ws=true`) | Run the full UDP-path registration logic; store the WebSocket sink in `tcp_punch`; return `true` to keep the connection alive for future server-push messages |
| 2 | `handle_udp_punch_hole_request`, `RequestRelay` | Check `peer_addr.port() == 0`; call `send_to_tcp` instead of the UDP channel |
| 3 | `send_to_tcp` | After delivery, re-insert the sink so the peer can receive multiple messages without reconnecting; fall back to UDP if no sink is present |
| 4 | `send_to_tcp_sync` | Same UDP fallback for consistency |

### End-to-end connection flow (both directions)

**Setup:** WebSocket peer A behind a reverse proxy, UDP peer B on a local network.

**A → B** (unchanged): A opens a WebSocket, sends `PunchHoleRequest`; sink stored in `tcp_punch`; hbbs delivers `FetchLocalAddr` to B via UDP; B responds via TCP with `PunchHoleSent`; hbbs delivers `PunchHoleResponse` to A via the stored sink.

**B → A** (new): B sends `PunchHoleRequest` via UDP; hbbs detects `A.socket_addr.port() == 0` and delivers `PunchHole` to A via `send_to_tcp` (sink re-inserted after use); A connects to relay and sends `PunchHoleSent`; `handle_hole_sent` calls `send_to_tcp` for B's addr — no sink found, falls back to UDP → B receives `PunchHoleResponse`; both sides connect to relay → bridged.

### Testing

Tested end-to-end with:
- **Peer A**: macOS client with `allow-websocket = Y`, connecting to hbbs via a Cloudflare tunnel (WebSocket over port 443)
- **Peer B**: Windows client on the same LAN as the server, using standard UDP/TCP on ports 21116/21117

Both directions (`A → B` and `B → A`) established relay connections successfully. Prior to this patch, `B → A` always timed out.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * WebSocket clients can register public keys and peers with UUID/IP validation, throttling, and explicit OK/UUID_MISMATCH/TOO_FREQUENT responses; online queries now respond via stored connections.

* **Improvements**
  * Relay routing respects peer-encoded port (zero = WebSocket-registered).
  * Delivery prefers stored WebSocket sinks, sends synchronously and immediately restores them to avoid race windows.
  * UDP fallback used when no direct sink is available.

* **Bug Fixes**
  * Punch-hole routing and error replies corrected for missing or unknown targets.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rustdesk/rustdesk-server/pull/657?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->