### PR TITLE
Fix i32 overflow: peers offline 24.9–49.7 days wrongly reported online

### DIFF
--- a/src/rendezvous_server.rs
+++ b/src/rendezvous_server.rs
@@ -47,7 +47,7 @@ enum Data {
     RelayServers(RelayServers),
 }
 
-const REG_TIMEOUT: i32 = 30_000;
+const REG_TIMEOUT: i64 = 30_000;
 type TcpStreamSink = SplitSink<Framed<TcpStream, BytesCodec>, Bytes>;
 type WsSink = SplitSink<tokio_tungstenite::WebSocketStream<TcpStream>, tungstenite::Message>;
 enum Sink {
@@ -697,7 +697,7 @@ impl RendezvousServer {
         if let Some(peer) = self.pm.get(&id).await {
             let (elapsed, peer_addr) = {
                 let r = peer.read().await;
-                (r.last_reg_time.elapsed().as_millis() as i32, r.socket_addr)
+                (r.last_reg_time.elapsed().as_millis() as i64, r.socket_addr)
             };
             if elapsed >= REG_TIMEOUT {
                 let mut msg_out = RendezvousMessage::new();
@@ -790,7 +790,7 @@ impl RendezvousServer {
         let mut states = BytesMut::zeroed((peers.len() + 7) / 8);
         for (i, peer_id) in peers.iter().enumerate() {
             if let Some(peer) = self.pm.get_in_memory(peer_id).await {
-                let elapsed = peer.read().await.last_reg_time.elapsed().as_millis() as i32;
+                let elapsed = peer.read().await.last_reg_time.elapsed().as_millis() as i64;
                 // bytes index from left to right
                 let states_idx = i / 8;
                 let bit_idx = 7 - i % 8;


### PR DESCRIPTION
Fixes #675 

## Problem

`hbbs` decides whether a peer is online by casting elapsed milliseconds to `i32`:

```rust
const REG_TIMEOUT: i32 = 30_000;
// handle_online_request()
let elapsed = peer.read().await.last_reg_time.elapsed().as_millis() as i32;
if elapsed < REG_TIMEOUT { /* mark ONLINE */ }
```

`Duration::as_millis()` returns a `u128`; casting it `as i32` keeps only the low 32 bits **as a signed integer**. Once a peer has not registered for more than `2^31` ms (**24.855 days**), the value wraps **negative**, so `elapsed < REG_TIMEOUT` is true and a long-offline peer is reported **online**. The same cast in `handle_punch_hole_request()` also makes the server treat such a peer as reachable and relay connection attempts to its stale `socket_addr`.

Because the in-memory peer map is never evicted, `last_reg_time` stays frozen at the last registration for as long as `hbbs` runs, so any peer offline between **24.86 and 49.71 days** shows online (repeating every ~49.71 days).

Worked example: a peer last seen 25.4 days ago → `elapsed = 2_196_120_000 ms`, `as i32 = -2_098_847_296`, and `-2_098_847_296 < 30_000` → reported online.

## Fix

Widen `REG_TIMEOUT` and the two `elapsed` casts from `i32` to `i64` so the comparison can't overflow (`i64` milliseconds won't wrap for any realistic uptime). No behavior change other than removing the overflow.

```diff
-const REG_TIMEOUT: i32 = 30_000;
+const REG_TIMEOUT: i64 = 30_000;

-                (r.last_reg_time.elapsed().as_millis() as i32, r.socket_addr)
+                (r.last_reg_time.elapsed().as_millis() as i64, r.socket_addr)

-                let elapsed = peer.read().await.last_reg_time.elapsed().as_millis() as i32;
+                let elapsed = peer.read().await.last_reg_time.elapsed().as_millis() as i64;
```

`REG_TIMEOUT` is only compared against these two `elapsed` values (in `handle_online_request` and `handle_punch_hole_request`), so the types stay consistent.

## Testing

On a self-hosted OSS `hbbs` (uptime 25.5 days) three peers that had been powered off since ~25 days earlier were reported online, and `tcpdump udp port 21116` showed zero registration packets from them (confirming they were genuinely offline). Restarting `hbbs` cleared the stale in-memory entries and they correctly showed offline — matching the overflow analysis above. With this change the elapsed comparison no longer wraps, so those peers report offline without needing a restart.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved time-based registration handling to prevent issues caused by large elapsed-time values.
  * Made timeout checks more reliable in online and connection-establishment flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->