### PR TITLE
Update protobuf to 3.7.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3027,9 +3027,9 @@ dependencies = [
 
 [[package]]
 name = "protobuf"
-version = "3.7.1"
+version = "3.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3a7c64d9bf75b1b8d981124c14c179074e8caa7dfe7b6a12e6222ddcd0c8f72"
+checksum = "d65a1d4ddae7d8b5de68153b48f6aa3bba8cb002b243dbdbc55a5afbc98f99f4"
 dependencies = [
  "bytes",
  "once_cell",
@@ -3039,9 +3039,9 @@ dependencies = [
 
 [[package]]
 name = "protobuf-codegen"
-version = "3.7.1"
+version = "3.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e26b833f144769a30e04b1db0146b2aaa53fd2fd83acf10a6b5f996606c18144"
+checksum = "5d3976825c0014bbd2f3b34f0001876604fe87e0c86cd8fa54251530f1544ace"
 dependencies = [
  "anyhow",
  "once_cell",
@@ -3054,9 +3054,9 @@ dependencies = [
 
 [[package]]
 name = "protobuf-parse"
-version = "3.7.1"
+version = "3.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "322330e133eab455718444b4e033ebfac7c6528972c784fcde28d2cc783c6257"
+checksum = "b4aeaa1f2460f1d348eeaeed86aea999ce98c1bded6f089ff8514c9d9dbdc973"
 dependencies = [
  "anyhow",
  "indexmap 2.7.0",
@@ -3070,9 +3070,9 @@ dependencies = [
 
 [[package]]
 name = "protobuf-support"
-version = "3.7.1"
+version = "3.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b088fd20b938a875ea00843b6faf48579462630015c3788d397ad6a786663252"
+checksum = "3e36c2f31e0a47f9280fb347ef5e461ffcd2c52dd520d8e216b52f93b0b0d7d6"
 dependencies = [
  "thiserror 1.0.31",
 ]

--- a/tests/protobuf_recursion.rs
+++ b/tests/protobuf_recursion.rs
@@ -2,6 +2,7 @@ use hbb_common::{protobuf::Message, rendezvous_proto::RendezvousMessage};
 use std::process::Command;
 
 const CHILD_ENV: &str = "RUSTDESK_PROTOBUF_RECURSION_CHILD";
+const CHILD_COMPLETION_SENTINEL: &str = "protobuf_recursion_child_completed";
 const TEST_NAME: &str = "deeply_nested_unknown_groups_are_rejected_without_aborting";
 
 #[test]
@@ -12,17 +13,22 @@ fn deeply_nested_unknown_groups_are_rejected_without_aborting() {
         input.extend(std::iter::repeat(0x0c).take(DEPTH));
 
         assert!(RendezvousMessage::parse_from_bytes(&input).is_err());
+        println!("{CHILD_COMPLETION_SENTINEL}");
         return;
     }
 
-    let status = Command::new(std::env::current_exe().expect("locate the test binary"))
+    let output = Command::new(std::env::current_exe().expect("locate the test binary"))
         .args(["--exact", TEST_NAME, "--nocapture"])
         .env(CHILD_ENV, "1")
-        .status()
+        .output()
         .expect("run the recursive-input check in an isolated process");
 
+    let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(
-        status.success(),
-        "parsing deeply nested unknown protobuf groups aborted the process: {status}"
+        output.status.success() && stdout.lines().any(|line| line == CHILD_COMPLETION_SENTINEL),
+        "child parser check did not complete successfully (status: {}):\nstdout:\n{}\nstderr:\n{}",
+        output.status,
+        stdout,
+        String::from_utf8_lossy(&output.stderr)
     );
 }

--- a/tests/protobuf_recursion.rs
+++ b/tests/protobuf_recursion.rs
@@ -1,0 +1,28 @@
+use hbb_common::{protobuf::Message, rendezvous_proto::RendezvousMessage};
+use std::process::Command;
+
+const CHILD_ENV: &str = "RUSTDESK_PROTOBUF_RECURSION_CHILD";
+const TEST_NAME: &str = "deeply_nested_unknown_groups_are_rejected_without_aborting";
+
+#[test]
+fn deeply_nested_unknown_groups_are_rejected_without_aborting() {
+    if std::env::var_os(CHILD_ENV).is_some() {
+        const DEPTH: usize = 300_000;
+        let mut input = vec![0x0b; DEPTH];
+        input.extend(std::iter::repeat(0x0c).take(DEPTH));
+
+        assert!(RendezvousMessage::parse_from_bytes(&input).is_err());
+        return;
+    }
+
+    let status = Command::new(std::env::current_exe().expect("locate the test binary"))
+        .args(["--exact", TEST_NAME, "--nocapture"])
+        .env(CHILD_ENV, "1")
+        .status()
+        .expect("run the recursive-input check in an isolated process");
+
+    assert!(
+        status.success(),
+        "parsing deeply nested unknown protobuf groups aborted the process: {status}"
+    );
+}


### PR DESCRIPTION
I have excess 5.6-sol and Fable 5 credits, and decided to use them to contribute back to OSS that I depend upon.

gpt5.6-sol cross-checked by Opus 4.8. Fable 5 could not cross-check due to safeties being triggered.

## What

- Update the locked `protobuf`, `protobuf-codegen`, `protobuf-parse`, and
  `protobuf-support` packages from 3.7.1 to 3.7.2.
- Add a regression that parses deeply nested unknown groups in an isolated
  child process and requires clean rejection without aborting.

## Why

Protobuf 3.7.1 is affected by
[RUSTSEC-2024-0437](https://rustsec.org/advisories/RUSTSEC-2024-0437.html).
Both RustDesk Server TCP services parse `RendezvousMessage` before
authentication or semantic union handling. With 3.7.1, a deeply nested
unknown-group payload can overflow the worker stack and abort the complete
process. The same input is rejected by 3.7.2.

The child-process structure is deliberate: if a vulnerable protobuf version is
resolved again, the abort becomes an ordinary parent-test failure instead of
terminating the test harness.

This uses the advisory's public fixed release and does not claim a new protobuf
vulnerability.

## Validation

- Regression sensitivity: fails cleanly with a SIGABRT child on 3.7.1 and
  passes on 3.7.2.
- Harness sensitivity: a deliberately stale exact test name ran zero tests and
  exited successfully, but emitted no completion sentinel and is rejected by
  the parent check.
- Focused recursion regression: pass.
- Serial workspace tests: 94 `hbb_common`, 1 `hbbs` library, and 1 new
  integration test passed; binary/doc targets also passed.
- `cargo check --workspace --locked`: pass.
- `rustfmt --check tests/protobuf_recursion.rs`: pass.
- `git diff --check`: pass.

Base:
`70dcfdeb95ccd848ff5dc64df69ff2da4131c5a8`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added a regression test to ensure extremely deep/recursive protobuf inputs with nested unknown groups are safely rejected.
  * Verifies parsing returns an error (no panic/abort) by running the check in an isolated child process and confirming the expected completion output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->